### PR TITLE
steal.options.env

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -809,7 +809,7 @@
 					} else if ( commaSplit[0] ) {
 						steal.options.app = commaSplit[0];
 					}
-					if ( steal.options.env != "production" ) {
+					if ( commaSplit[1] && steal.options.env != "production" ) {
 						steal.options.env = commaSplit[1];
 					}
 				}


### PR DESCRIPTION
This fixes a case when no environment is specified, steal.options.env is set to undefined when it should stay as "development".
