### PR TITLE
Compress option for pluginify

### DIFF
--- a/build/pluginify/pluginify.js
+++ b/build/pluginify/pluginify.js
@@ -71,6 +71,7 @@ steal("//steal/build/pluginify/parse").plugins('steal/build/scripts').then(
 			var compressor = steal.build.builders.scripts.compressors[compressorName]()
 			output = compressor(output);
 		}
+
 		print("--> " + destination);
 		new steal.File(destination).save(output);
 		//print("pluginified " + plugin)


### PR DESCRIPTION
I added a compress option to pluginify.js so that it can be used like:

```
js steal/pluginifyjs mxui/slider -nojquery -compress
```

Or

```
js steal/pluginifyjs mxui/slider -nojquery -compress shrinksafe
```
