### PR TITLE
Race conditions in IE9 when using load event for script elements

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -103,12 +103,9 @@
 				scriptTag += steal.loadErrorTimer(options);
 			}
 			scriptTag += '>' + (bodyText || '') + '</script>';
-			if ( steal.support.load ) {
-				scriptTag += '<script type="text/javascript"' + '>steal.end()</script>';
-			}
-			else {
-				scriptTag += '<script type="text/javascript" src="' + steal.root.join('steal/end.js') + '"></script>';
-			}
+
+			scriptTag += '<script type="text/javascript" src="' + steal.root.join('steal/end.js') + '"></script>';
+
 			document.write((options.src || bodyText ? scriptTag : ''));
 		};
 


### PR DESCRIPTION
The implementation of the load event for script elements in IE9 works really strange. In other words it is not working as it should!! Some parts of the code were called asynchronously and messed everything up.
So I removed the load event support in the insert function. Might not be the best solution as improving "eventSupported" would be better but it took me almost 4 hours to figure this out :) So it is up to you what you are going to implement.

Good to know that IE9 will be the same crap as all previous versions ;)
