### PR TITLE
Fix so that steal("./resources/underscore.js") and steal("//app/resources

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -566,6 +566,10 @@
 					paths = this.path.split('/'),
 					path = paths[0];
 				
+				while (path === "." && paths.length > 0) {
+					paths.shift();
+					path = paths[0];
+				}
 				//if we are joining from a folder like cookbook/, remove the last empty part
 				if ( url.match(/\/$/) ) {
 					urls.pop();

--- a/test/qunit/steal_test.js
+++ b/test/qunit/steal_test.js
@@ -41,6 +41,12 @@ test("joinFrom", function() {
 	
 	result = new steal.File('../../up.js').joinFrom('cookbook/')
 	equals(result, "../up.js", "up.js is correctly joined.")
+
+	result = new steal.File("./a/b").joinFrom("http://abc.com/");
+	equals(result, "http://abc.com/a/b", "./a/b joined correctly with http://abc.com/");
+
+	result = new steal.File("./a/b").joinFrom("../d/e");
+	equals(result, "../d/e/a/b", "./a/b joined correctly from ../d/e");
 })
 
 test("dir", function() {


### PR DESCRIPTION
I was noticing that I was sometimes getting files stolen more than once.  I tracked it down to one location where I had:

``` javascript
steal("//bpa/resources/underscore.js")
```

and in some other dependency that resides in the "resources" folder:

``` javascript
steal("./underscore.js");
```

Was due to the absolute path for the second case resolving to

```
//bpa/resources/./underscore.js
```
