### PR TITLE
Update to less 1.1.3 and fix for a couple of path issues in steal/less

### DIFF
--- a/less/less.js
+++ b/less/less.js
@@ -59,7 +59,7 @@ steal({path: "less_engine.js",ignore: true},function(){
 		var current, path;
 		for(var i=0; i < arguments.length; i++){
 			current = new steal.File(arguments[i]+".less").joinCurrent();
-			path = steal.root.join(current)
+			path = steal.root.join(current);
 			if(steal.browser.rhino){
 				//rhino will just look for this
 				steal.createLink(path, {
@@ -71,9 +71,17 @@ steal({path: "less_engine.js",ignore: true},function(){
 					steal.dev.warn("steal/less : There's no content at "+path+", or you're on the filesystem and it's in another folder.");
 					return steal;
 				}
+				
+				var locParts = location.href.split('#');
+				
+				if(path.indexOf('/') == 0) {
+					path = path.substr(1); // Prevent double // in newPath
+				}
+				
 				// less needs the full path with http:// or file://
-				var newPath = location.href.replace(/[\w\.-]+$/, '')+
+				var newPath = locParts[0].replace(/[\w\.-]+$/, '') +
 					path.replace(/[\w\.-]+$/, '');
+
 				//get and insert stype
 				new (less.Parser)({
 	                optimization: less.optimization,
@@ -109,12 +117,15 @@ steal({path: "less_engine.js",ignore: true},function(){
 	}
 	//@steal-remove-start
 	steal.build.types['text/less'] =  function(script, loadScriptText){
+		var pathParts = script.href.split('/');
+		pathParts[pathParts.length - 1] = ''; // Remove filename
+
 		var text =   script.text || loadScriptText(script.href, script),
 			styles;
 		new (less.Parser)({
-	                optimization: less.optimization,
-	                paths: []
-	            }).parse(text, function (e, root) {
+				optimization: less.optimization,
+				paths: [pathParts.join('/')]
+				}).parse(text, function (e, root) {
 					styles = root.toCSS();
 				});
 		return styles;

--- a/less/less_engine.js
+++ b/less/less_engine.js
@@ -1,8 +1,8 @@
 //
-// LESS - Leaner CSS v1.0.41
+// LESS - Leaner CSS v1.1.3
 // http://lesscss.org
 // 
-// Copyright (c) 2010, Alexis Sellier
+// Copyright (c) 2009-2011, Alexis Sellier
 // Licensed under the Apache 2.0 License.
 //
 (function (window, undefined) {
@@ -198,7 +198,7 @@ less.Parser = function Parser(env) {
         queue: [],                      // Files which haven't been imported yet
         files: {},                      // Holds the imported parse trees
         mime:  env && env.mime,         // MIME type of .less files
-        push: function (path, callback) {
+        push: function (path, callback) {        
             var that = this;
             this.queue.push(path);
 
@@ -229,7 +229,7 @@ less.Parser = function Parser(env) {
     // Parse from a token, regexp or string, and move forward if match
     //
     function $(tok) {
-        var match, args, length, c, index, endIndex, k;
+        var match, args, length, c, index, endIndex, k, mem;
 
         //
         // Non-terminal
@@ -327,11 +327,12 @@ less.Parser = function Parser(env) {
             // Split the input into chunks.
             chunks = (function (chunks) {
                 var j = 0,
-                    skip = /[^"'`\{\}\/]+/g,
+                    skip = /[^"'`\{\}\/\(\)]+/g,
                     comment = /\/\*(?:[^*]|\*+[^\/*])*\*+\/|\/\/.*/g,
                     level = 0,
                     match,
                     chunk = chunks[0],
+                    inParam,
                     inString;
 
                 for (var i = 0, c, cc; i < input.length; i++) {
@@ -345,7 +346,7 @@ less.Parser = function Parser(env) {
                     c = input.charAt(i);
                     comment.lastIndex = i;
 
-                    if (!inString && c === '/') {
+                    if (!inString && !inParam && c === '/') {
                         cc = input.charAt(i + 1);
                         if (cc === '/' || cc === '*') {
                             if (match = comment.exec(input)) {
@@ -358,11 +359,17 @@ less.Parser = function Parser(env) {
                         }
                     }
 
-                    if        (c === '{' && !inString) { level ++;
+                    if        (c === '{' && !inString && !inParam) { level ++;
                         chunk.push(c);
-                    } else if (c === '}' && !inString) { level --;
+                    } else if (c === '}' && !inString && !inParam) { level --;
                         chunk.push(c);
                         chunks[++j] = chunk = [];
+                    } else if (c === '(' && !inString && !inParam) {
+                        chunk.push(c);
+                        inParam = true;
+                    } else if (c === ')' && !inString && inParam) {
+                        chunk.push(c);
+                        inParam = false;
                     } else {
                         if (c === '"' || c === "'" || c === '`') {
                             if (! inString) {
@@ -485,6 +492,7 @@ less.Parser = function Parser(env) {
                 error = {
                     name: "ParseError",
                     message: "Syntax Error on line " + line,
+                    index: i,
                     filename: env.filename,
                     line: line,
                     column: column,
@@ -584,11 +592,15 @@ less.Parser = function Parser(env) {
                 //     "milky way" 'he\'s the one!'
                 //
                 quoted: function () {
-                    var str;
-                    if (input.charAt(i) !== '"' && input.charAt(i) !== "'") return;
+                    var str, j = i, e;
+
+                    if (input.charAt(j) === '~') { j++, e = true } // Escaped strings
+                    if (input.charAt(j) !== '"' && input.charAt(j) !== "'") return;
+
+                    e && $('~');
 
                     if (str = $(/^"((?:[^"\\\r\n]|\\.)*)"|'((?:[^'\\\r\n]|\\.)*)'/)) {
-                        return new(tree.Quoted)(str[0], str[1] || str[2]);
+                        return new(tree.Quoted)(str[0], str[1] || str[2], e);
                     }
                 },
 
@@ -613,22 +625,24 @@ less.Parser = function Parser(env) {
                 // The arguments are parsed with the `entities.arguments` parser.
                 //
                 call: function () {
-                    var name, args;
+                    var name, args, index = i;
 
                     if (! (name = /^([\w-]+|%)\(/.exec(chunks[j]))) return;
 
                     name = name[1].toLowerCase();
 
                     if (name === 'url') { return null }
-                    else                { i += name.length + 1 }
+                    else                { i += name.length }
 
                     if (name === 'alpha') { return $(this.alpha) }
+
+                    $('('); // Parse the '(' and consume whitespace.
 
                     args = $(this.entities.arguments);
 
                     if (! $(')')) return;
 
-                    if (name) { return new(tree.Call)(name, args) }
+                    if (name) { return new(tree.Call)(name, args, index) }
                 },
                 arguments: function () {
                     var args = [], arg;
@@ -657,7 +671,7 @@ less.Parser = function Parser(env) {
 
                     if (input.charAt(i) !== 'u' || !$(/^url\(/)) return;
                     value = $(this.entities.quoted)  || $(this.entities.variable) ||
-                            $(this.entities.dataURI) || $(/^[-\w%@$\/.&=:;#+?]+/) || "";
+                            $(this.entities.dataURI) || $(/^[-\w%@$\/.&=:;#+?~]+/) || "";
                     if (! $(')')) throw new(Error)("missing closing ) for url()");
 
                     return new(tree.URL)((value.value || value.data || value instanceof tree.Variable)
@@ -689,7 +703,7 @@ less.Parser = function Parser(env) {
                 variable: function () {
                     var name, index = i;
 
-                    if (input.charAt(i) === '@' && (name = $(/^@[\w-]+/))) {
+                    if (input.charAt(i) === '@' && (name = $(/^@@?[\w-]+/))) {
                         return new(tree.Variable)(name, index);
                     }
                 },
@@ -729,12 +743,15 @@ less.Parser = function Parser(env) {
                 //     `window.location.href`
                 //
                 javascript: function () {
-                    var str;
+                    var str, j = i, e;
 
-                    if (input.charAt(i) !== '`') { return }
+                    if (input.charAt(j) === '~') { j++, e = true } // Escaped strings
+                    if (input.charAt(j) !== '`') { return }
+
+                    e && $('~');
 
                     if (str = $(/^`([^`]*)`/)) {
-                        return new(tree.JavaScript)(str[1], i);
+                        return new(tree.JavaScript)(str[1], i, e);
                     }
                 }
             },
@@ -861,7 +878,8 @@ less.Parser = function Parser(env) {
             //
             entity: function () {
                 return $(this.entities.literal) || $(this.entities.variable) || $(this.entities.url) ||
-                       $(this.entities.call)    || $(this.entities.keyword)  || $(this.entities.javascript);
+                       $(this.entities.call)    || $(this.entities.keyword)  || $(this.entities.javascript) ||
+                       $(this.comment);
             },
 
             //
@@ -881,7 +899,7 @@ less.Parser = function Parser(env) {
             alpha: function () {
                 var value;
 
-                if (! $(/^opacity=/i)) return;
+                if (! $(/^\(opacity=/i)) return;
                 if (value = $(/^\d+/) || $(this.entities.variable)) {
                     if (! $(')')) throw new(Error)("missing closing ) for alpha()");
                     return new(tree.Alpha)(value);
@@ -901,7 +919,7 @@ less.Parser = function Parser(env) {
             // and an element name, such as a tag a class, or `*`.
             //
             element: function () {
-                var e, t;
+                var e, t, c;
 
                 c = $(this.combinator);
                 e = $(/^(?:[.#]?|:*)(?:[\w-]|\\(?:[a-fA-F0-9]{1,6} ?|[^a-fA-F0-9]))+/) || $('*') || $(this.attribute) || $(/^\([^)@]+\)/);
@@ -1000,9 +1018,10 @@ less.Parser = function Parser(env) {
                 } else {
                     while (s = $(this.selector)) {
                         selectors.push(s);
+                        $(this.comment);
                         if (! $(',')) { break }
+                        $(this.comment);
                     }
-                    if (s) $(this.comment);
                 }
 
                 if (selectors.length > 0 && (rules = $(this.block))) {
@@ -1014,7 +1033,7 @@ less.Parser = function Parser(env) {
                 }
             },
             rule: function () {
-                var name, value, c = input.charAt(i), important;
+                var name, value, c = input.charAt(i), important, match;
                 save();
 
                 if (c === '.' || c === '#' || c === '&') { return }
@@ -1070,7 +1089,7 @@ less.Parser = function Parser(env) {
 
                 if (value = $(this['import'])) {
                     return value;
-                } else if (name = $(/^@media|@page/)) {
+                } else if (name = $(/^@media|@page|@-[-a-z]+/)) {
                     types = ($(/^[^{]+/) || '').trim();
                     if (rules = $(this.block)) {
                         return new(tree.Directive)(name + " " + types, rules);
@@ -1159,9 +1178,14 @@ less.Parser = function Parser(env) {
             // such as a Color, or a Variable
             //
             operand: function () {
-                return $(this.sub) || $(this.entities.dimension) ||
-                       $(this.entities.color) || $(this.entities.variable) ||
-                       $(this.entities.call);
+                var negate, p = input.charAt(i + 1);
+
+                if (input.charAt(i) === '-' && (p === '@' || p === '(')) { negate = $('-') }
+                var o = $(this.sub) || $(this.entities.dimension) ||
+                        $(this.entities.color) || $(this.entities.variable) ||
+                        $(this.entities.call);
+                return negate ? new(tree.Operation)('*', [new(tree.Dimension)(-1), o])
+                              : o;
             },
 
             //
@@ -1200,6 +1224,7 @@ if (typeof(window) !== 'undefined') {
         if (path.charAt(0) !== '/' && paths.length > 0) {
             path = paths[0] + path;
         }
+
         // We pass `true` as 3rd argument, to force the reload of the import.
         // This is so we can get the syntax tree as opposed to just the CSS output,
         // as we need this to evaluate the current stylesheet.
@@ -1329,16 +1354,33 @@ tree.functions = {
     e: function (str) {
         return new(tree.Anonymous)(str instanceof tree.JavaScript ? str.evaluated : str);
     },
+    escape: function (str) {
+        return new(tree.Anonymous)(encodeURI(str.value).replace(/=/g, "%3D").replace(/:/g, "%3A").replace(/#/g, "%23").replace(/;/g, "%3B").replace(/\(/g, "%28").replace(/\)/g, "%29"));
+    },
     '%': function (quoted /* arg, arg, ...*/) {
         var args = Array.prototype.slice.call(arguments, 1),
             str = quoted.value;
 
         for (var i = 0; i < args.length; i++) {
-            str = str.replace(/%s/,    args[i].value)
-                     .replace(/%[da]/, args[i].toCSS());
+            str = str.replace(/%[sda]/i, function(token) {
+                var value = token.match(/s/i) ? args[i].value : args[i].toCSS();
+                return token.match(/[A-Z]$/) ? encodeURIComponent(value) : value;
+            });
         }
         str = str.replace(/%%/g, '%');
         return new(tree.Quoted)('"' + str + '"', str);
+    },
+    round: function (n) {
+        if (n instanceof tree.Dimension) {
+            return new(tree.Dimension)(Math.round(number(n)), n.unit);
+        } else if (typeof(n) === 'number') {
+            return Math.round(n);
+        } else {
+	    throw {
+                error: "RuntimeError",
+                message: "math functions take numbers as parameters"
+            };
+        }
     }
 };
 
@@ -1374,7 +1416,10 @@ tree.Alpha.prototype = {
         return "alpha(opacity=" +
                (this.value.toCSS ? this.value.toCSS() : this.value) + ")";
     },
-    eval: function () { return this }
+    eval: function (env) {
+        if (this.value.eval) { this.value = this.value.eval(env) }
+        return this;
+    }
 };
 
 })(require('less/tree'));
@@ -1396,9 +1441,10 @@ tree.Anonymous.prototype = {
 //
 // A function call node.
 //
-tree.Call = function (name, args) {
+tree.Call = function (name, args, index) {
     this.name = name;
     this.args = args;
+    this.index = index;
 };
 tree.Call.prototype = {
     //
@@ -1417,7 +1463,12 @@ tree.Call.prototype = {
         var args = this.args.map(function (a) { return a.eval(env) });
 
         if (this.name in tree.functions) { // 1.
-            return tree.functions[this.name].apply(tree.functions, args);
+            try {
+                return tree.functions[this.name].apply(tree.functions, args);
+            } catch (e) {
+                throw { message: "error evaluating function `" + this.name + "`",
+                        index: this.index };
+            }
         } else { // 2.
             return new(tree.Anonymous)(this.name +
                    "(" + args.map(function (a) { return a.toCSS() }).join(', ') + ")");
@@ -1445,6 +1496,11 @@ tree.Color = function (rgb, a) {
         this.rgb = rgb;
     } else if (rgb.length == 6) {
         this.rgb = rgb.match(/.{2}/g).map(function (c) {
+            return parseInt(c, 16);
+        });
+    } else if (rgb.length == 8) {
+        this.alpha = parseInt(rgb.substring(0,2), 16) / 255.0;
+        this.rgb = rgb.substr(2).match(/.{2}/g).map(function (c) {
             return parseInt(c, 16);
         });
     } else {
@@ -1493,7 +1549,7 @@ tree.Color.prototype = {
         for (var c = 0; c < 3; c++) {
             result[c] = tree.operate(op, this.rgb[c], other.rgb[c]);
         }
-        return new(tree.Color)(result);
+        return new(tree.Color)(result, this.alpha + other.alpha);
     },
 
     toHSL: function () {
@@ -1645,8 +1701,10 @@ tree.Expression.prototype = {
             return new(tree.Expression)(this.value.map(function (e) {
                 return e.eval(env);
             }));
-        } else {
+        } else if (this.value.length === 1) {
             return this.value[0].eval(env);
+        } else {
+            return this;
         }
     },
     toCSS: function (env) {
@@ -1736,18 +1794,27 @@ tree.Import.prototype = {
 })(require('less/tree'));
 (function (tree) {
 
-tree.JavaScript = function (string, index) {
+tree.JavaScript = function (string, index, escaped) {
+    this.escaped = escaped;
     this.expression = string;
     this.index = index;
 };
 tree.JavaScript.prototype = {
-    toCSS: function () {
-        return JSON.stringify(this.evaluated);
-    },
     eval: function (env) {
         var result,
-            expression = new(Function)('return (' + this.expression + ')'),
+            that = this,
             context = {};
+
+        var expression = this.expression.replace(/@\{([\w-]+)\}/g, function (_, name) {
+            return tree.jsify(new(tree.Variable)('@' + name, that.index).eval(env));
+        });
+
+        try {
+            expression = new(Function)('return (' + expression + ')');
+        } catch (e) {
+            throw { message: "JavaScript evaluation error: `" + expression + "`" ,
+                    index: this.index };
+        }
 
         for (var k in env.frames[0].variables()) {
             context[k.slice(1)] = {
@@ -1759,12 +1826,18 @@ tree.JavaScript.prototype = {
         }
 
         try {
-            this.evaluated = expression.call(context);
+            result = expression.call(context);
         } catch (e) {
             throw { message: "JavaScript evaluation error: '" + e.name + ': ' + e.message + "'" ,
                     index: this.index };
         }
-        return this;
+        if (typeof(result) === 'string') {
+            return new(tree.Quoted)('"' + result + '"', result, this.escaped, this.index);
+        } else if (Array.isArray(result)) {
+            return new(tree.Anonymous)(result.join(', '));
+        } else {
+            return new(tree.Anonymous)(result);
+        }
     }
 };
 
@@ -1789,12 +1862,13 @@ tree.mixin.Call = function (elements, args, index) {
 };
 tree.mixin.Call.prototype = {
     eval: function (env) {
-        var mixins, rules = [], match = false;
+        var mixins, args, rules = [], match = false;
 
         for (var i = 0; i < env.frames.length; i++) {
             if ((mixins = env.frames[i].find(this.selector)).length > 0) {
+                args = this.arguments && this.arguments.map(function (a) { return a.eval(env) });
                 for (var m = 0; m < mixins.length; m++) {
-                    if (mixins[m].match(this.arguments, env)) {
+                    if (mixins[m].match(args, env)) {
                         try {
                             Array.prototype.push.apply(
                                   rules, mixins[m].eval(env, this.arguments).rules);
@@ -1843,7 +1917,7 @@ tree.mixin.Definition.prototype = {
     rulesets:  function ()     { return this.parent.rulesets.apply(this) },
 
     eval: function (env, args) {
-        var frame = new(tree.Ruleset)(null, []), context;
+        var frame = new(tree.Ruleset)(null, []), context, _arguments = [];
 
         for (var i = 0, val; i < this.params.length; i++) {
             if (this.params[i].name) {
@@ -1855,6 +1929,11 @@ tree.mixin.Definition.prototype = {
                 }
             }
         }
+        for (var i = 0; i < Math.max(this.params.length, args && args.length); i++) {
+            _arguments.push(args[i] || this.params[i].value);
+        }
+        frame.rules.unshift(new(tree.Rule)('@arguments', new(tree.Expression)(_arguments).eval(env)));
+
         return new(tree.Ruleset)(null, this.rules.slice(0)).eval({
             frames: [this, frame].concat(this.frames, env.frames)
         });
@@ -1913,16 +1992,29 @@ tree.operate = function (op, a, b) {
 })(require('less/tree'));
 (function (tree) {
 
-tree.Quoted = function (str, content) {
+tree.Quoted = function (str, content, escaped, i) {
+    this.escaped = escaped;
     this.value = content || '';
     this.quote = str.charAt(0);
+    this.index = i;
 };
 tree.Quoted.prototype = {
     toCSS: function () {
-        return this.quote + this.value + this.quote;
+        if (this.escaped) {
+            return this.value;
+        } else {
+            return this.quote + this.value + this.quote;
+        }
     },
-    eval: function () {
-        return this;
+    eval: function (env) {
+        var that = this;
+        var value = this.value.replace(/`([^`]+)`/g, function (_, exp) {
+            return new(tree.JavaScript)(exp, that.index, true).eval(env).value;
+        }).replace(/@\{([\w-]+)\}/g, function (_, name) {
+            var v = new(tree.Variable)('@' + name, that.index).eval(env);
+            return v.value || v.toCSS();
+        });
+        return new(tree.Quoted)(this.quote + value + this.quote, value, this.escaped, this.index);
     }
 };
 
@@ -2179,7 +2271,7 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (!/^(?:https?:\/|file:\/)?\//.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
+        if (!/^(?:https?:\/|file:\/|data:\/)?\//.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
             val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
         this.value = val;
@@ -2228,13 +2320,17 @@ tree.Variable.prototype = {
     eval: function (env) {
         var variable, v, name = this.name;
 
+        if (name.indexOf('@@') == 0) {
+            name = '@' + new(tree.Variable)(name.slice(1)).eval(env).value;
+        }
+
         if (variable = tree.find(env.frames, function (frame) {
             if (v = frame.variable(name)) {
                 return v.value.eval(env);
             }
         })) { return variable }
         else {
-            throw { message: "variable " + this.name + " is undefined",
+            throw { message: "variable " + name + " is undefined",
                     index: this.index };
         }
     }
@@ -2247,12 +2343,20 @@ require('less/tree').find = function (obj, fun) {
     }
     return null;
 };
+require('less/tree').jsify = function (obj) {
+    if (Array.isArray(obj.value) && (obj.value.length > 1)) {
+        return '[' + obj.value.map(function (v) { return v.toCSS(false) }).join(', ') + ']';
+    } else {
+        return obj.toCSS(false);
+    }
+};
 //
 // browser.js - client-side engine
 //
 
 var isFileProtocol = (location.protocol === 'file:'    ||
                       location.protocol === 'chrome:'  ||
+                      location.protocol === 'chrome-extension:'  ||
                       location.protocol === 'resource:');
 
 less.env = less.env || (location.hostname == '127.0.0.1' ||
@@ -2323,7 +2427,8 @@ for (var i = 0; i < links.length; i++) {
 
 
 less.refresh = function (reload) {
-    var startTime = endTime = new(Date);
+    var startTime, endTime;
+    startTime = endTime = new(Date);
 
     loadStyleSheets(function (root, sheet, env) {
         if (env.local) {
@@ -2370,7 +2475,11 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
 
     // Stylesheets in IE don't always return the full path
     if (! /^(https?|file):/.test(href)) {
-        href = url.slice(0, url.lastIndexOf('/') + 1) + href;
+        if (href.charAt(0) == "/") {
+            href = window.location.protocol + "//" + window.location.host + href;
+        } else {
+            href = url.slice(0, url.lastIndexOf('/') + 1) + href;
+        }
     }
 
     xhr(sheet.href, sheet.type, function (data, lastModified) {


### PR DESCRIPTION
This changeset updates steal to less 1.1.3 and fixes the following issues:
1. If a hash (#) was in the URL, the import path used by less also contained that hash and sometimes also the string after the hash. This should be fixed with lines 75 to 82.
2. `@import` calls in less scripts didn't work during compression, because the relative path was not passed on to less. This should be fixed with lines 120 to 127.
