### PR TITLE
Disables less when running on the command line (Rhino)

### DIFF
--- a/less/less.js
+++ b/less/less.js
@@ -1,3 +1,4 @@
+if (!navigator.userAgent.match(/Rhino/)) {
 /**
  * @add steal.static
  */
@@ -121,3 +122,6 @@ steal({path: "less_engine.js",ignore: true},function(){
 	}
 	//@steal-remove-end
 })
+} else {
+	steal.less = function () {};
+}


### PR DESCRIPTION
Disables less when running on the command line via Rhino. The less plugin caused the unit test script to hang after execution, because Rhino did not exit. Also less is not required for the unit tests anyways and this change should speed up the execution a little bit. Downside is, that the qunit test for less itself needs a real browser now, but I guess it didn't work on Rhino before anyways.

See https://github.com/jupiterjs/steal/issues/29#issuecomment-1514743
