### PR TITLE
Fixes issues in async steal with IE and CSS

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -1305,9 +1305,11 @@ steal.type("text", function(options, original, success, error){
 steal.type("css", function css_type(options, original, success, error){
 	if(options.text){
 		var css  = document.createElement('style')
-		if (css.styleSheet) { // IE
-            css.styleSheet.cssText = options.text;
-	    } else {
+		if (typeof css.styleSheet != 'undefined') { // IE
+			setTimeout(function () {
+				css.styleSheet.cssText = options.text;
+			}, 10);
+		} else {
 	        (function (node) {
 	            if (css.childNodes.length > 0) {
 	                if (css.firstChild.nodeValue !== node.nodeValue) {


### PR DESCRIPTION
I noticed that css.styleSheet is an empty object in IE because of some timing issue. This change fixes the bug by explicitly testing if styleSheet is undefined and then waiting until the object was properly initialized.
