### PR TITLE
Revert "Implemented steal.dev.log() as equivalent to console.log() as proposed in https://github.com/jupiterjs/steal/issues/21"

### DIFF
--- a/dev/dev.js
+++ b/dev/dev.js
@@ -51,8 +51,7 @@ steal.dev = {
 	warn: function( out ) {
 		if(steal.options.logLevel < 2){
 			if ( window.console && console.log ) {
-			   Array.prototype.unshift.call(arguments, 'steal.js WARNING:');
-				console.log.apply(console, arguments);
+				console.log("steal.js WARNING: " + out);
 			} else if ( window.opera && window.opera.postError ) {
 				opera.postError("steal.js WARNING: " + out);
 			}
@@ -69,8 +68,7 @@ steal.dev = {
 	log: function( out ) {
 		if (steal.options.logLevel < 1) {
 			if (window.console && console.log) {
-			   Array.prototype.unshift.call(arguments, 'steal.js INFO:');
-				console.log.apply(console, arguments);
+				console.log("steal.js INFO: " + out);
 			}
 			else if (window.opera && window.opera.postError) {
 				opera.postError("steal.js INFO: " + out);


### PR DESCRIPTION
Not sure how this got into the master branch - the change was rejected by Brian, see comments: https://github.com/jupiterjs/steal/pull/22

This reverts commit 3c526977028e465b6d7a1aca5252a9c4a48439ba.
