### PR TITLE
Allow changing the list of steal files in before callback

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -825,8 +825,12 @@
 			steal.require(this.options,this.orig, function load_calling_loaded(script){
 				self.loaded(script);
 			}, function(error, src){
-				clearTimeout(self.completeTimeout)
-				throw "steal.js : "+self.options.src+" not completed"
+				if (!self.options.optional){
+					clearTimeout(self.completeTimeout);
+					throw "steal.js : "+self.options.src+" not completed";
+				}else{
+					self.loaded("");
+				}
 			});
 			
 		}


### PR DESCRIPTION
Hi,
I did this modification in our project to be able to alter the list of files that steal is going to download at runtime.
I use this primary to  be able to download different file versions based on some central configuration, without modifying initial startup file. And also to try downloading locale specific versions of scripts.

Thought it can be usefull.

Were there any special reason why you pass a copy of arguments array to before and after callbacks?

Regards,
Dmytro
