### PR TITLE
Fix steal.request to handle negative status codes and IE exceptions.

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -1462,9 +1462,9 @@ request = function(options, success, error){
 		check = function(){
 			if ( request.readyState === 4 )  {
 				if ( request.status === 500 || request.status === 404 || 
-					 request.status === 2 || 
+					 request.status === 2 || request.status < 0 || 
 					 (request.status === 0 && request.responseText === '') ) {
-					error && error();
+					error && error(request.status);
 					clean();
 				} else {
 					success(request.responseText);
@@ -1487,9 +1487,11 @@ request = function(options, success, error){
 		request.send(null);
 	}
 	catch (e) {
-		console.error(e);
-		error && error();
-		clean();
+		if (clean) {
+			console.error(e);
+			error && error();
+			clean();
+		}
 	}
 			 
 };


### PR DESCRIPTION
1) Check for request.status<0 to call error instead of success. Safari generates negative request.status codes (-1100) with missing URLs on file:// requests. 
2) Make sure clean has not already been called in catch. If the request.status is 2 (missing file), error and clean will be called from the check function. In IE, an exception is also thrown afterwards. In catch, make sure that clean and error have not already been called from check to prevent duplicate call to error for same request, and prevent an exception from being thrown from a call to the already nulled clean method.
3. If the URL errors, pass the request.status code to error to allow for branched handing based on type (404 vs 500 etc).
