### PR TITLE
Log additional information when localClosure errors out

### DIFF
--- a/build/scripts/scripts.js
+++ b/build/scripts/scripts.js
@@ -330,6 +330,11 @@ steal('steal/build', 'steal/parse').then(function( steal ) {
 								error = errMatch[2];
 							while (!found) {
 								item = currentLineMap[i];
+								if (!item) {
+								        steal.print("Invalid line: lineNumber=" + lineNbr + ", error=" + options.err);
+								        // optional
+								        throw new Error("Invalid line in currentLineMap, lineNumber=" + lineNbr + ", error=" + options.err);
+								}
 								lineCount += item.lines;
 								if (lineCount >= lineNbr) {
 									found = true;


### PR DESCRIPTION
Help provide additional information when the localClosure process runs into an issue with one of your JavaScript files when building production.js.

See: https://forum.javascriptmvc.com/topic/build-js-error-when-compiling-app
