### PR TITLE
localStorage didn't reveal error

### DIFF
--- a/build/scripts/scripts.js
+++ b/build/scripts/scripts.js
@@ -315,7 +315,7 @@ steal('steal/build', 'steal/parse').then(function( steal ) {
 				// if there's an error, go through the lines and find the right location
 				if( /ERROR/.test(options.err) ){
 					if (!currentLineMap) {
-						print(options.error)
+						print(options.err)
 					}
 					else {
 					


### PR DESCRIPTION
in localStorage there's a typo about options.error; it should be options.err.
With the typo nothing will be shown when error happens.
