### PR TITLE
js script always returns exit status '0', regardless of java process status

### DIFF
--- a/js
+++ b/js
@@ -51,7 +51,8 @@ done
 ARGS=$ARGS]
 java -Xmx512m -Xss1024k -cp $CP org.mozilla.javascript.tools.shell.Main -e _args=$ARGS -opt -1 -e 'load('"'"$1"'"')'
 
-if [ $ERRORLEV = "1" -a $? = "1" ]
+EXITSTATUS=$?
+if [ $ERRORLEV = "1" ]
 then
-	exit $?
+	exit $EXITSTATUS
 fi


### PR DESCRIPTION
The if block at the end of the js script will always cause the script to exit with code 0, regardless of if the -e option was used or not. The code in question is:

<pre>
java -Xmx512m -Xss1024k -cp $CP org.mozilla.javascript.tools.shell.Main -e _args=$ARGS -opt -1 -e 'load('"'"$1"'"')'

if [ $ERRORLEV = "1" -a $? = "1" ]
then
    exit $?
fi
</pre>


In the if [...] expression, $? contains the exit status of the java process, as intended. But in the then clause it contains the result of the just evaluated if expression, which will be 0 if the then clause is reached.

The intention of the above code seems to be to only fail the script if the java process exits with status 1. This pull request makes the script return the exit code of the java process directly if the -e option is used.
