### PR TITLE
Fixed: url()s to files outside the JSMVC root, were badly converted for production.css

### DIFF
--- a/build/styles/test/styles_test.js
+++ b/build/styles/test/styles_test.js
@@ -73,4 +73,46 @@ steal('steal/test', function( s ) {
 		
 		s.test.clear();
 	});
+
+	s.test.test("ensure urls references updated correctly after building to a different folder", function(){
+		load('steal/rhino/rhino.js');
+
+		// setup where the package will be built to
+		var packagePath = 'test_packages/production.css';
+		var dest = steal.File(packagePath);
+		var packageDir = dest.dir();
+		var packageDirFile = steal.File(packageDir);
+		if(!packageDirFile.exists()){
+			packageDirFile.mkdir();
+		}
+
+		// build the package
+		steal('steal/build',
+			'steal/build/styles',
+			function(){
+				steal.build('steal/build/styles/test/testurls/testurls.html',
+					{to: packageDir});
+			});
+
+		// now, check the paths are what we expect.
+		var prod = readFile(packagePath);
+		s.test.ok(
+			prod.match(new RegExp("url\\(\\.\\./steal/build/styles/test/testurls/child/path/image.png\\)")),
+			"child path reference correct");
+		s.test.ok(
+			prod.match(new RegExp("url\\(\\.\\./steal/build/styles/sibling/path/image.png\\)")),
+			"sibling path reference correct");
+		s.test.ok(
+			prod.match(new RegExp("url\\(\\.\\./\\.\\./outside/jsmvcroot/image.png\\)")),
+			"external path reference correct");
+
+		// cleanup
+		var prodFile = steal.File(packagePath);
+		prodFile.remove();
+		packageDirFile.removeDir();
+		s.test.clear();
+	});
+
+
+
 });

--- a/build/styles/test/testurls/testurls.css
+++ b/build/styles/test/testurls/testurls.css
@@ -1,0 +1,10 @@
+#a {
+    background-image: url(child/path/image.png);
+}
+#b {
+    background-image: url(../../sibling/path/image.png);
+}
+#c {
+    background-image: url(../../../../../../outside/jsmvcroot/image.png);
+}
+

--- a/build/styles/test/testurls/testurls.html
+++ b/build/styles/test/testurls/testurls.html
@@ -1,0 +1,14 @@
+<html>
+	<head>
+		<title>testurls</title>
+	</head>
+	<body>
+	    <h1>testurls Test</h1>
+		<script type='text/javascript' 
+                src='../../../../steal.js?steal/build/styles/test/testurls'>
+        </script>
+
+	</body>
+</html>
+
+

--- a/build/styles/test/testurls/testurls.js
+++ b/build/styles/test/testurls/testurls.js
@@ -1,0 +1,1 @@
+steal('./testurls.css')

--- a/rhino/file.js
+++ b/rhino/file.js
@@ -107,15 +107,27 @@
 				return u.protocol() + "//" + u.domain() + this.path;
 			}
 			else {
+				if ( url === '' ) {
+					return this.path.replace(/\/$/, '');
+				}
 
-				if ( url == '' ) return this.path.replace(/\/$/, '');
 				var urls = url.split('/'),
-					paths = this.path.split('/'),
-					path = paths[0];
-				if ( url.match(/\/$/) ) urls.pop();
-				while ( path == '..' && paths.length > 0 ) {
-					paths.shift();
+						paths = this.path.split('/'),
+						path = paths[0];
+
+				//if we are joining from a folder like cookbook/, remove the last empty part
+				if ( url.match(/\/$/) ) {
 					urls.pop();
+				}
+				// for each .. remove one folder
+				while ( path == '..' && paths.length > 0 ) {
+					// if we've emptied out, folders, just break
+					// leaving any additional ../s
+					if(! urls.pop() ){
+						break;
+					}
+					paths.shift();
+
 					path = paths[0];
 				}
 				return urls.concat(paths).join('/');


### PR DESCRIPTION
### Overview

When a stylesheet uses a relative url() reference to a file that lies outside/above the JSMVC root, and production.css is built, it will convert the url() to an incorrect path. It might also be necessary to build production.css to a different path.
### Testing

See the updated test case:
`./js steal/build/styles/test/styles_test.js`
### Notes
- The fix was to update `File.joinFrom()` in `steal/rhino/file.js` with the slightly updated `File.joinFrom()` in `steal/steal.js`. However, there's probably a bigger issue here, since both File interfaces have almost identical code -> issues due to violating DRY.
- This is the same issue as described in #81. However, that issue isn't well described, nor is there a test to ensure it works...
