### PR TITLE
Fix getCachedInteractiveScript() always returning null

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -2000,18 +2000,17 @@ var interactiveScript,
 		}
 	},
 	getCachedInteractiveScript = function() {
-		var script;
 		if (interactiveScript && interactiveScript.readyState === "interactive") {
 			return interactiveScript;
 		}
-
-			return null;
-		};
-
+		
 		// check last inserted
-		if(lastInserted && lastInserted.readyState == "interactive"){
+		if(lastInserted && lastInserted.readyState == "interactive") {
 			return lastInserted;
 		}
+		
+		return null;
+	};
 
 
 support.interactive = doc && !!getInteractiveScript();


### PR DESCRIPTION
Fixes my issue, but I think the function sitll isn't as "clean" as it should be (the variable _interactiveScript_ is never assigned for example)
https://github.com/jupiterjs/steal/issues/85#issuecomment-6322704
