### PR TITLE
added replacement of blank spaces with %20 (tests pending)

### DIFF
--- a/rhino/env.js
+++ b/rhino/env.js
@@ -1622,7 +1622,9 @@ Envjs.getcwd = function() {
  
  */
 Envjs.uri = function(path, base, allow) {
-	path = path.replace(/\\/g, '/');
+	path = "" + path
+                    .replace(/\\/g, '/')
+                    .replace(/ /g, '%20');
     //console.log('constructing uri from path %s and base %s', path, base);
 
     // Semi-common trick is to make an iframe with src='javascript:false'


### PR DESCRIPTION
I recently had the issue that we have a blank space in the path where our JMVC app is located. Unfortunately we cannot change that whitespace. The problem is that the build terminates with some Java uri format exception.

I traced the problem down to env.js which apparently does no encoding of the URI. The fix provided in this pull request seems to resolve the issue. Unfortunately I was not able to execute the automated tests (btw, could you include a guide on running them on the main readme.md of your project??). What I did, though, was to execute a couple of builds with the modified env.js on different projects in our codebase and it seemed to work properly.

Related links:
- http://forum.javascriptmvc.com/topic/build-js-on-windows-with-space-in-user-error
