### PR TITLE
Add meaningful error reporting to less handler

### DIFF
--- a/less/less.js
+++ b/less/less.js
@@ -66,12 +66,16 @@ steal({id: "./less_engine.js",ignore: true}, function(){
 			pathParts[pathParts.length - 1] = ''; // Remove filename
 			paths = [pathParts.join('/')];
 		}
-		new (less.Parser)({
-            optimization: less.optimization,
-            paths: [pathParts.join('/')]
-        }).parse(options.text, function (e, root) {
-			options.text = root.toCSS();
-			success();
-		});
+		try {
+			new (less.Parser)({
+	            optimization: less.optimization,
+	            paths: [pathParts.join('/')]
+	        }).parse(options.text, function (e, root) {
+				options.text = root.toCSS();
+				success();
+			});
+		} catch(e) {
+			console.log(e);
+		}
 	});
 })


### PR DESCRIPTION
Show actual error instead of something like 
uncaught exception: [object Object]
which makes it really hard to debug less errors
