### PR TITLE
Fix error when a shim has a non-steal dep and an exports function

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -1592,10 +1592,10 @@
 					this.unique = false;
 				} else {
 					if(h.isString(options)) {
-                        options = {
-                            id: options
-                        }
-                    }
+						options = {
+							id: options
+						}
+					}
 					// save the original options
 					this.options = steal.makeOptions(h.extend({}, options), this.curId);
 


### PR DESCRIPTION
If a shim specifies a non-steal dependency (via deps) and an exports function, Steal will throw a JS error because the module.options is a String just before makeOptions is called.

This fix catches this case and turns options into an Object with the id set to the String value as expected.

**stealconfig.js**

``` js
...
shim: {
    'dollar': {
        exports: 'dollar'
    },
    'dollar.plugin': {
        deps: ['dollar'],
        exports: function($) {
            ...
        }
    }
}
...
```
