### PR TITLE
escapes slash char in regex

### DIFF
--- a/instrument/process.js
+++ b/instrument/process.js
@@ -1380,7 +1380,7 @@ function gen_code(ast, options) {
         function encode_string(str) {
                 var ret = make_string(str, options.ascii_only);
                 if (options.inline_script)
-                        ret = ret.replace(/<\x2fscript([>/\t\n\f\r ])/gi, "<\\/script$1");
+                        ret = ret.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
                 return ret;
         };
 
@@ -1858,7 +1858,7 @@ function gen_code(ast, options) {
                         name = add_spaces([ make_name(name), "=", parenthesize(val, "seq") ]);
                 return name;
         };
-        
+
 
 };
 


### PR DESCRIPTION
JSLint complained..the slash hasn't been escaped in the regex
