### PR TITLE
jQuery 1.9.1 ready handlers shouldn't be triggered during `steal.build.open()`.

### DIFF
--- a/build/open/open.js
+++ b/build/open/open.js
@@ -281,6 +281,9 @@ steal('steal',function(s){
 				"jquery.1.8.1.js": function( script ) {
 					window.jQuery && jQuery.holdReady(true);
 				},
+				"jquery.1.9.1.js": function( script ) {
+					window.jQuery && jQuery.holdReady(true);
+				},
 				"steal.js": function(script){
 					if(stealData.skipAll){
 						window.steal.config({


### PR DESCRIPTION
This preserves the behavior that prevents jQuery ready handlers from triggering, in `steal.build.open()`. 

You'll see from the diff that jQuery 1.7.1 and 1.8.1 have the appropriate handling, but jQuery 1.9.1 (packaged with current versions of CanJS) does not. This means that AJAX requests and other undesirable code are being triggered when building against jQuery 1.9.1 only, breaking the build process.

Please note, this fix is not a good long term solution, since other/future versions of jQuery will each need to be explicitly added. Developers that change their version of jQuery may not be aware of this.
