### PR TITLE
Update instrument.utils.parentWindow to handle iframes better

### DIFF
--- a/instrument/utils.js
+++ b/instrument/utils.js
@@ -93,15 +93,14 @@ steal.instrument.utils = {
 			return;
 		}
 		var win = window;
-		if(top !== window){
-			win = top;
-		}
 		try{
 			if(win.opener && win.opener.steal){
 				win = win.opener;
+			}else if (win.iframe && win.iframe.contentWindow.steal) {
+				win = win.iframe.contentWindow;
 			}
 		}catch(e){}
-		
+
 		return win;
 	}
 }


### PR DESCRIPTION
When loading steal apps within an iframe, parentWindow was getting caught up and steal.instrument wasn't being found.
