### PR TITLE
Retain query and fragment URI parts from CSS src properties when packaging production.css

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -623,7 +623,8 @@ h.extend(URI.prototype, {
 			part = right[0];
 		}
 		return h.extend(URI(this.domain() + left.concat(right).join("/")), {
-			query: uri.query
+			query: uri.query,
+			fragment: uri.fragment
 		});
 	},
 	/**
@@ -695,7 +696,7 @@ h.extend(URI.prototype, {
 		h.each(thisParts, function() {
 			result.push("../")
 		})
-		return URI(result.join("") + uriParts.join("/"));
+		return URI(result.join("") + uriParts.join("/") + (uri.query ? ("?" + uri.query) : ""));
 	},
 	mapJoin: function( url ) {
 		return this.join(URI(url).insertMapping());


### PR DESCRIPTION
These get lost in production when stealing CSS, e.g:

@font-face {
  font-family: 'FontAwesome';
  src: url('../fonts/fontawesome-webfont.eot?v=4.0.3');
  src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg');
  font-weight: normal;
  font-style: normal;
}

... ends up as:

@font-face{font-family:'FontAwesome';src:url(../../lib/font-awesome/fonts/fontawesome-webfont.eot);src:url(../../lib/font-awesome/fonts/fontawesome-webfont.eot)... etc
