### PR TITLE
Make quotes optional in regexp to get url from css.

### DIFF
--- a/test/css_paths/main.js
+++ b/test/css_paths/main.js
@@ -1,11 +1,9 @@
 import 'css_paths/folder/main.less!steal/less';
 import 'css_paths/folder/main.css!';
 
-
 if(typeof window !== "undefined" && window.QUnit) {
 	var image = new Image();
 	image.onload = function(){
-		
 		QUnit.ok(true, "image loaded");
 		QUnit.start();
 		removeMyself();
@@ -15,7 +13,7 @@ if(typeof window !== "undefined" && window.QUnit) {
 		QUnit.start();
 		removeMyself();
 	};
-	image.src = $("#test-element1").css("background-image").replace(/url\("/,"").replace(/"\)/,"");
+	image.src = $("#test-element1").css("background-image").replace(/url\("?/,"").replace(/"?\)/,"");
 } else {
 	console.log("background-image", $("#test-element1").css("background-image"));
 }


### PR DESCRIPTION
Firefox wraps the url from background-image with quotes but Chrome does not.
