### PR TITLE
Update to Traceur 0.52

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,6 @@
     "systemjs" : "git://github.com/bitovi/systemjs.git#1ea63e1d855694aab0ba73e742b2c9cd00388669"
   },
   "dependencies": {
-    "traceur": "0.0.45"
+    "traceur": "0.0.52"
   }
 }


### PR DESCRIPTION
Using the old 0.45 was causing tests to break in Travis. This updates to 0.52 which is the same version as is used by the ES6-Module-Loader we are using.
