### PR TITLE
Fixes tests not running in Travis

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,9 +91,9 @@ module.exports = function (grunt) {
     testee: {
       tests: {
         options: {
-          browsers: ['firefox'],
-          urls: ['test/test.html']
-        }
+          browsers: ['firefox']
+        },
+        src: ['test/test.html']
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "~0.3.0",
     "grunt-release": "^0.7.0",
-    "testee": "git://github.com/bitovi/testee.js.git#master"
+    "testee": "~0.1.1"
   },
   "licenses": [
     {

--- a/test/test.html
+++ b/test/test.html
@@ -19,5 +19,8 @@
 		<script src="../bower_components/qunit/qunit/qunit.js"></script>
 		
 		<script src="test.js"></script>
+    <script>
+      delete window.define;
+    </script>
 	</body>
 </html>


### PR DESCRIPTION
Tests weren't running in Travis because we were using Testee #master
which had changed the way it's Grunt task worked. So I'm updated the
task and set a version number of Testee to use so this doesn't happen
again.
