### PR TITLE
Explain wildcard paths (docs)

### DIFF
--- a/docs/system-paths.md
+++ b/docs/system-paths.md
@@ -17,10 +17,28 @@ will provide [default paths](#section_Defaultpathsconfiguredbysteal).
 
 ## Use
 
-`System.paths` can be configued with any of the approaches in [System.config]. For example:
+`System.paths` can be configured with any of the approaches in [System.config]. It
+is used to provide the path of a module. You might use this if you install a module
+with a package manager, for example with bower. For example:
+
+    System.paths.jquery = "bower_components/jquery/dist/jquery.js"
+
+Will map the the `jquery` module to where the JavaScript file is located in bower_components.
+
+### Wildcard paths
+
+The `*` is used to denote wildcard paths. These allow substitution in cases where
+you want a common pattern for referring to module names. A common example of this
+would be a package where you want to load only certain modules and not the `main`
+module.
+
+For example:
 
     System.paths['lodash/*'] = '/js/lodash/*.js'
     System.paths["theme/*"] = "jquery-ui/themes/base/jquery.ui.*css"
+
+This would allow you to do: `import throttle from "lodash/functions/throttle"` to
+load only the throttle function.
 
 See [this issue](https://github.com/systemjs/systemjs/issues/113) on why `css` and other extensions have
 strange rules.


### PR DESCRIPTION
This adds an explanation about wildcard paths to the `System.paths` documentation.
