### PR TITLE
Fix some documentation format issues.

### DIFF
--- a/docs/module-loader.md
+++ b/docs/module-loader.md
@@ -20,9 +20,9 @@ would use [System].
     import loader from "@loader";
 
     loader.config({
-		map: {
-			"can/util/util": "can/util/jquery/jquery"
-		}
+      map: {
+        "can/util/util": "can/util/jquery/jquery"
+      }
     });
 
 This works with any syntax supported by StealJS.

--- a/docs/pages/migrating.md
+++ b/docs/pages/migrating.md
@@ -14,7 +14,7 @@ There is no longer a `"*"` mapping like before:
       map: {
         "*": {
           "can/util": "can/util/jquery"
-				}
+        }
       }
     });
 
@@ -70,11 +70,11 @@ Steal compiles the `less` files in a slightly different way than the legacy vers
 
 In the legacy Steal, you `@import`-ed stuff relative from the location of the `.less` file:
 
-    @import '../../../styles/variables.less';
+    @import "../../../styles/variables.less";
 
 In the new Steal `@import` path are relative to the steal root folder - folder that contains the `stealconfig.js` file:
 
-    @import 'styles/variables.less';
+    @import "styles/variables.less";
 
 The opposite is the case for the image urls in your `.less` files:
 

--- a/docs/steal.md
+++ b/docs/steal.md
@@ -16,17 +16,17 @@ After installing with bower or
 [downloading](https://github.com/bitovi/steal/archive/master.zip),
 add `steal.js` to your page like:
 
-    <script src='../path/to/steal/steal.js`
-            config='./config.js'
-            main='myapp'>
+    <script src="../path/to/steal/steal.js"
+            config="./config.js"
+            main="myapp">
     </script>
 
 This will load `config.js` which can be used to configure the behavior of
 your site's modules. For example, to load jQuery from a CDN:
 
-     //config.js
+     // config.js
      System.config({
-       paths: {'jquery': "http://code.jquery.com/jquery-1.11.0.min.js"}
+       paths: {"jquery": "http://code.jquery.com/jquery-1.11.0.min.js"}
      });
 
 And it will load `myapp.js`. `myapp.js` can import
@@ -34,7 +34,7 @@ dependencies in any syntax it choses. For those betting on the future,
 use the upcoming [syntax.es6 ES6 module syntax]:
 
     // myapp.js
-    import $ from 'jquery'
+    import $ from "jquery"
     $(document.body).appendChild("<h1>Hello World</h1>");
 
 ## Client Use
@@ -50,11 +50,11 @@ The basic use of `steal.js` is broken into three parts:
 To load [steal] in the browser add a `<script>` tag who's source
 points to `steal.js` like:
 
-    <script src='../path/to/steal/steal.js'></script>
+    <script src="../path/to/steal/steal.js"></script>
 
 With this, you can begin loading modules using [System.import]. For example:
 
-    <script src='../path/to/steal/steal.js'></script>
+    <script src="../path/to/steal/steal.js"></script>
     <script>
       System.import("myapp").then(function(main){
         // main loaded successfully
@@ -75,29 +75,30 @@ configuration values.  Configuration values can be set in three ways:
         <script>
           steal = {main: "myapp"};
         </script>
-        <script src='../path/to/steal/steal.js'></script>
+        <script src="../path/to/steal/steal.js"></script>
    
  - Attributes on the steal.js script tag like:
   
-        <script src='../path/to/steal/steal.js'
-                main="myapp"></script>
+        <script src="../path/to/steal/steal.js"
+                main="myapp">
+        </script>
  
  - Calling [System.config] or setting `System` configuration properties
    after `steal.js` has loaded. This technique is typically used in the [@config] module.
-  
+
         System.config({
           paths: {"can/*" : "http://canjs.com/release/2.0.1/can/*"}
         })
         System.meta["jquery"] = {format: "global"}
-        
+
 Typically, developers configure the [System.main] and [System.configPath] properties 
 with attributes on the steal.js script tag like:
 
-    <script src='../path/to/steal/steal.js'
+    <script src="../path/to/steal/steal.js"
             main="myapp"
-            config-path="../config.js"
-            ></script>
-        
+            config-path="../config.js">
+    </script>
+
 Setting [System.configPath] sets [System.baseURL] to the 
 configPath's parent directory.  This would load `config.js` prior to
 loading `../myapp.js`.
@@ -106,8 +107,9 @@ When steal.js loads, it sets [System.stealPath].  This sets default values
 for [System.baseURL] and [System.configPath]. If `steal.js` is in `bower_components`,
 [System.configPath] defaults to `bower_components` parent folder. So if you write:
 
-    <script src='../../bower_components/steal/steal.js'
-            main="myapp"></script>
+    <script src="../../bower_components/steal/steal.js"
+            main="myapp">
+    </script>
 
 This will load `../../stealconfig.js` before it loads `../../myapp.js`.
 

--- a/docs/stealjs.md
+++ b/docs/stealjs.md
@@ -77,8 +77,9 @@ tells steal to load the `main` module.
     <!DOCTYPE html>
     <html>
       <body>
-        <script src='./bower_components/steal/steal.js'
-                data-main='main'></script>
+        <script src="./bower_components/steal/steal.js"
+                data-main="main">
+        </script>
       </body>
     </html>
 
@@ -122,8 +123,8 @@ call `stealBuild`
           }
         }
       });
-      grunt.loadNpmTasks('steal-tools');
-      grunt.registerTask('build',['stealBuild']);
+      grunt.loadNpmTasks("steal-tools");
+      grunt.registerTask("build",["stealBuild"]);
     };
 
 After saving `Gruntfile.js` run:
@@ -137,8 +138,9 @@ Change `index.html` to look like:
     <!DOCTYPE html>
     <html>
       <body>
-        <script src='./bower_components/steal/steal.production.js'
-                data-main='main'></script>
+        <script src="./bower_components/steal/steal.production.js"
+                data-main="main">
+        </script>
       </body>
     </html>
 

--- a/docs/syntax-amd.md
+++ b/docs/syntax-amd.md
@@ -24,8 +24,8 @@ AMD also provides a conventient syntax that can be used rather than providing a 
 
     define(function(require, exports, module){
       var can = require("can/can");
-			var _ = require("underscore/underscore");
-			var myModule = require("my_module/my_module");
+      var _ = require("underscore/underscore");
+      var myModule = require("my_module/my_module");
 
-			return ...
+      return ...
     });

--- a/docs/syntax-global.md
+++ b/docs/syntax-global.md
@@ -11,7 +11,7 @@ it uses the "global" syntax.
 A global module might look like:
 
     // app/sample-global.js
-    hello = 'world';
+    hello = "world";
      
 Use [System.meta] to configure this module as the global format like:
 
@@ -23,7 +23,7 @@ can also be set inline like:
     // app/sample-global.js
     "format global";
     "exports hello";
-    hello = 'world';
+    hello = "world";
 
 ## Implementation 
 

--- a/docs/system-bundlesPath.md
+++ b/docs/system-bundlesPath.md
@@ -20,7 +20,8 @@ a `"bundles/myapp"` module is automatically configured to contain it:
     <script src="steal/steal.js"
             config="./config.js"
             main="myapp"
-            env="production"></script>
+            env="production">
+    </script>
     <script>
       System.bundles["bundles/myapp"] //-> ["myapp"]
     </script>
@@ -33,7 +34,8 @@ a `"bundles/myapp"` module is automatically configured to contain it:
             config="./config.js"
             main="myapp"
             env="production"
-            bundles-path="packages"></script>
+            bundles-path="packages">
+    </script>
     <script>
       System.bundles["bundles/myapp"] //-> ["myapp"]
       System.paths["bundles/*"] = "packages/*.js";
@@ -47,7 +49,8 @@ Often, `bundlesPath` should be the same value as what's passed in [stealTools.bu
             config="./config.js"
             main="myapp"
             env="production"
-            bundles-path="packages"></script>
+            bundles-path="packages">
+    </script>
     <script>
       System.bundles["bundles/myapp"] //-> ["myapp"]
       System.paths["bundles/*"] = "dist/bundles/*.js";

--- a/docs/system-env.md
+++ b/docs/system-env.md
@@ -33,7 +33,8 @@ be [System.config configured] via the `steal.js` script tag like:
 
     <script src="../path/to/steal/steal.js"
             data-env="production"
-            data-main="myapp"></script>
+            data-main="myapp">
+    </script>
             
 Or specified prior to steal loading like:
 
@@ -41,5 +42,6 @@ Or specified prior to steal loading like:
       steal = {env: "production"}
     </script>
     <script src="../path/to/steal/steal.js"
-            data-env="production"></script>
+            data-env="production">
+    </script>
 

--- a/docs/system-instantiated.md
+++ b/docs/system-instantiated.md
@@ -20,6 +20,7 @@ prevents the production bundle from loading:
         }
       }
     </script>
-    <script src='../../steal/steal.js'
-            main='myapp'
-            env='production'></script>
+    <script src="../../steal/steal.js"
+            main="myapp"
+            env="production">
+    </script>

--- a/docs/system-paths.md
+++ b/docs/system-paths.md
@@ -34,7 +34,7 @@ module.
 
 For example:
 
-    System.paths['lodash/*'] = '/js/lodash/*.js'
+    System.paths["lodash/*"] = "/js/lodash/*.js"
     System.paths["theme/*"] = "jquery-ui/themes/base/jquery.ui.*css"
 
 This would allow you to do: `import throttle from "lodash/functions/throttle"` to


### PR DESCRIPTION
- Fix typo (backtip instead of quote)
- Use consistent indentation in code examples
- Use consistenly double quotes through code examples
- Use consistent indentation for `script` tags examples
