### PR TITLE
Document uses for map

### DIFF
--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -6,7 +6,7 @@ Alter [moduleName]s.
 @option {Object.<moduleGlob, moduleName|Object.<moduleGlob,moduleName>>} 
 
 Specifies rules to convert an imported moduleName to another module name. The rules can
-be specified globaly or limited to a specific path.
+be specified globally or limited to a specific path.
 
 The following will alter "glob/*" modules across the whole application.
 
@@ -20,6 +20,36 @@ The following limits converting "jquery" to "jquery@1.2" to only within modules 
     };
 
 @body
+
+## Uses
+
+Map is useful when you want to exchange one module for another.
+
+### Alternative implementation
+
+There are many libraries that share a common API. Consider a legacy application 
+that heavily used Underscore. You might want to migrate to Lodash for added 
+features or performance reasons. You can use map to do this without updating all of 
+your code that uses Underscore like so:
+
+    System.map.underscore = "lodash";
+
+This would save you from updating every module that had previously imported Underscore,
+however in some cases you are unable to update the modules in the first place  
+because they are third party libraries. Consider a MVC library that has a dependency
+on jQuery. If you wanted to use the smaller alternative Zepto you could simply
+map `jquery` to `zepto` and the MVC library would use that instead.
+
+### Ignoring optional dependencies
+
+Some modules might have dependencies on other modules that they only use as an option
+if you need them. Because there isn't a standard way to define conditional dependencies
+they likely just import them explicitly. If you do not need this option you can
+elect to ignore the dependency by mapping it to `@empty`:
+
+    System.map["some/optional_dep"] = "@empty";
+
+`@empty` is a pseudo-module defined by SystemJS to represent a module with no value.
 
 ## Implementation
 

--- a/test/map-empty/main.js
+++ b/test/map-empty/main.js
@@ -1,0 +1,5 @@
+steal("./other.js", function(other) {
+	 return {
+		other: other
+	 };
+});

--- a/test/map-empty/other.js
+++ b/test/map-empty/other.js
@@ -1,0 +1,3 @@
+define([], function() {
+	throw "This should have been ignored";
+});

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,16 @@ QUnit.config.testTimeout = 30000;
 		});
 	});
 
+	asyncTest("ignoring an import by mapping to @empty", function(){
+		System.map["map-empty/other"] = "@empty";
+		System["import"]("map-empty/main").then(function(m) {
+			var empty = System.get("@empty");
+			equal(m.other, empty, "Other is an empty module because it was mapped to empty in the config");
+		}, function(){
+			ok(false, "Loaded a module that should have been ignored");
+		}).then(start);
+	});
+
 
 	module("steal via html");
 


### PR DESCRIPTION
This adds documentation to `map` on a couple of common uses. One is using a different implementation of a common API. The other is ignoring an optional dependency.

This also adds a test for the scenario where map is used to ignore a dependency.

Closes #283
