### PR TITLE
Use latest version of system-bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "traceur": "0.0.58",
-	"system-bower": "~0.0.1"
+	"system-bower": "^0.0.3"
   }
 }


### PR DESCRIPTION
This changes our bower.json file so that we always use the latest version of system-bower
