### PR TITLE
Create sourceMaps for less during the build

### DIFF
--- a/ext/less.js
+++ b/ext/less.js
@@ -26,6 +26,8 @@ exports.translate = function(load) {
 		options.paths = [pathParts.join('/')];
 
 		var done = function(output) {
+			// Put the source map on metadata if one was created.
+			load.metadata.map = output.map;
 			resolve(output.css);
 		};
 


### PR DESCRIPTION
To create sourceMaps during dev the appropriate option is set by steal-tools. But we still need to store the created map somewhere, so we're going to put it on `load.metadata.map`.