### PR TITLE
Move error logging to where startup is called

### DIFF
--- a/src/end.js
+++ b/src/end.js
@@ -1,7 +1,11 @@
 	if (typeof window != 'undefined') {
 		var oldSteal = window.steal;
 		window.steal = makeSteal(System);
-		window.steal.startup(oldSteal && typeof oldSteal == 'object' && oldSteal  );
+		window.steal.startup(oldSteal && typeof oldSteal == 'object' && oldSteal)
+			.then(null, function(error){
+				console.log("error",error,  error.stack);
+				throw error;
+			});
 		window.steal.addSteal = addSteal;
 		
 		// I think production needs this

--- a/src/startup.js
+++ b/src/startup.js
@@ -118,9 +118,6 @@
 				return Promise.all( map(main,function(main){
 					return System["import"](main);
 				}) );
-			}).then(null, function(error){
-				console.log("error",error,  error.stack);
-				throw error;
 			});
 			
 		}


### PR DESCRIPTION
Instead of logging inside of startup, log where startup is called in the browser. This prevents noisy errors during watch mode when a file doesn't exist (which isn\'t a problem in that scenario). Fixes #394