### PR TITLE
Use system-bower 0.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "qunit": "~1.12.0",
     "systemjs": "bitovi/systemjs#0.16.6-bitovi.2",
     "traceur": "0.0.87",
-    "system-bower": "~0.1.0",
+    "system-bower": "^0.2.1",
     "es6-module-loader": "bitovi/es6-module-loader#v0.16.3-bitovi.2",
     "traceur-runtime": "~0.0.87"
   }

--- a/docs/module-bower.md
+++ b/docs/module-bower.md
@@ -64,6 +64,23 @@ in your `<script>` tag).
 
 By default, any property on the package.system object is passed to [System.config]. A few properties have special behavior, however:
 
+### package.system.main
+
+The moduleName of the initial module that shoudl be loaded when the package is imported. This overrides the `package.main` value. Useful when you need to have a `main` that is available for all bower users (like a global script) and a main available for users of the bower plugin (perhaps the CommonJS source):
+
+```json
+{
+  "name": "my-module",
+  "version": "1.0.0",
+  "main": "dist/global.js",
+  "system": {
+    "main": "my-main"
+  }
+}
+```
+
+This will load `my-main` as the main module instead of `dist/global.js`.
+
 ### package.system.bowerIgnore
 
 Use bowerIgnore to specify dependencies to prevent package information from being loaded. The following example ignores the bower package `jquery-cookie`:

--- a/docs/module-bower.md
+++ b/docs/module-bower.md
@@ -64,6 +64,24 @@ in your `<script>` tag).
 
 By default, any property on the package.system object is passed to [System.config]. A few properties have special behavior, however:
 
+### package.system.bowerIgnore
+
+Use bowerIgnore to specify dependencies to prevent package information from being loaded. The following example ignores the bower package `jquery-cookie`:
+
+```js
+{
+  "dependencies": {
+    "can": "2.2.4",
+    "jquery-cookie": "1.0.0"
+  },
+  "system": {
+    "bowerIgnore": [ "jquery-cookie" ]
+  }
+}
+```
+
+This will load `can` but ignore `jquery-cookie`.
+
 ### package.system.configDependencies
 
 Defines dependencies of your bower package. This is useful for loading modules,

--- a/docs/module-npm.md
+++ b/docs/module-npm.md
@@ -156,7 +156,7 @@ dependencies will be loaded:
 ```js
 {
   "dependencies": {
-    "canjs": "2.1.0",
+    "can": "2.2.4",
     "cssify": "^0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This upgrades the local `ext/bower.js` to be `0.2.0`. Includes the addition of `system.bowerIgnore` and `system.main`. Documentation for these features is included.