### PR TITLE
Default bowerPath config loading.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bower_components/
 test/ext/
 test/bower/as_config/vendor/system-bower/
 test/npm-deep/node_modules/steal/
+test/bower/as_config/vendor/steal/

--- a/src/config.js
+++ b/src/config.js
@@ -319,7 +319,7 @@
 					if(!cfg.root && !cfg.baseUrl && !cfg.baseURL && !cfg.config && !cfg.configPath ) {
 						if ( last(parts) === "steal" ) {
 							parts.pop();
-							if ( last(parts) === "bower_components" ) {
+							if ( last(parts) === cfg.bowerPath || "bower_components" ) {
 								System.configMain = "bower.json!bower";
 								addProductionBundles.call(this);
 								parts.pop();

--- a/test/bower/as_config/default-config.html
+++ b/test/bower/as_config/default-config.html
@@ -3,6 +3,6 @@
 	window.QUnit = window.parent.QUnit;
 	window.removeMyself = window.parent.removeMyself;
 </script>
-<script type="text/javascript" src='../../bower_components/steal/steal.js'
+<script type="text/javascript" src='vendor/steal/steal.js'
         main="main" data-bower-path="vendor"></script>
 </body>


### PR DESCRIPTION
Loading steal failed when steal was in custom bowerPath. Test case of as_config/default-config is updated to show the failing test.

Fix is in 0078d9a.