### PR TITLE
Upgrade to system-npm 0.3.0

### DIFF
--- a/ext/npm.js
+++ b/ext/npm.js
@@ -63,9 +63,16 @@ exports.translate = function(load){
 			}
 		});
 		var configDependencies = ['@loader','npm-extension'].concat(configDeps.call(loader, pkg));
-		var pkgMain = utils.pkg.hasDirectoriesLib(pkg) ?
-			convertName(context, pkg, false, true, pkg.name+"/"+utils.pkg.main(pkg)) :
-			utils.pkg.main(pkg);
+		var pkgMain = utils.pkg.main(pkg);
+		// Convert the main if using directories.lib
+		if(utils.pkg.hasDirectoriesLib(pkg)) {
+			var mainHasPkg = pkgMain.indexOf(pkg.name) === 0;
+			if(mainHasPkg) {
+				pkgMain = convertName(context, pkg, false, true, pkgMain);
+			} else {
+				pkgMain = convertName(context, pkg, false, true, pkg.name+"/"+pkgMain);
+			}
+		}
 
 		return "define("+JSON.stringify(configDependencies)+", function(loader, npmExtension){\n" +
 			"npmExtension.addExtension(loader);\n"+
@@ -164,7 +171,7 @@ function convertName (context, pkg, map, root, name) {
 				} else {
 					var requestedProject = crawl.getDependencyMap(context.loader, pkg, root)[parsed.packageName];
 					if(!requestedProject) {
-						warn(name);
+						if(root) warn(name);
 						return name;
 					}
 					requestedVersion = requestedProject.version;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "steal-css": "^0.0.4",
-    "system-npm": "^0.2.0",
+    "system-npm": "^0.3.0",
     "system-live-reload": "~0.0.2",
     "bower": "1.3.8",
     "grunt": "~0.4.1",

--- a/steal.production.js
+++ b/steal.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v0.10.5
+ *  steal v0.11.0-pre.0
  *  
  *  Copyright (c) 2015 Bitovi; Licensed MIT
  */

--- a/test/ext/npm.js
+++ b/test/ext/npm.js
@@ -63,9 +63,16 @@ exports.translate = function(load){
 			}
 		});
 		var configDependencies = ['@loader','npm-extension'].concat(configDeps.call(loader, pkg));
-		var pkgMain = utils.pkg.hasDirectoriesLib(pkg) ?
-			convertName(context, pkg, false, true, pkg.name+"/"+utils.pkg.main(pkg)) :
-			utils.pkg.main(pkg);
+		var pkgMain = utils.pkg.main(pkg);
+		// Convert the main if using directories.lib
+		if(utils.pkg.hasDirectoriesLib(pkg)) {
+			var mainHasPkg = pkgMain.indexOf(pkg.name) === 0;
+			if(mainHasPkg) {
+				pkgMain = convertName(context, pkg, false, true, pkgMain);
+			} else {
+				pkgMain = convertName(context, pkg, false, true, pkg.name+"/"+pkgMain);
+			}
+		}
 
 		return "define("+JSON.stringify(configDependencies)+", function(loader, npmExtension){\n" +
 			"npmExtension.addExtension(loader);\n"+
@@ -164,7 +171,7 @@ function convertName (context, pkg, map, root, name) {
 				} else {
 					var requestedProject = crawl.getDependencyMap(context.loader, pkg, root)[parsed.packageName];
 					if(!requestedProject) {
-						warn(name);
+						if(root) warn(name);
 						return name;
 					}
 					requestedVersion = requestedProject.version;


### PR DESCRIPTION
system-npm 0.3.0 includes a fix for setting the main when the package name is included.