### PR TITLE
Upgrade to live-reload 1.1.1

### DIFF
--- a/ext/live-reload.js
+++ b/ext/live-reload.js
@@ -221,7 +221,7 @@ function removeOrphans(moduleName, oldDeps){
 }
 
 function setup(){
-	if(loader.liveReload === "false") {
+	if(loader.liveReload === "false" || loader.liveReload === false) {
 		return;
 	}
 


### PR DESCRIPTION
This upgrades us to live-reload 1.1.1.  This version allows you to turn off live-reload with a configuration option: `System.liveReload = false;`. This was needed for the server side rendering live-reload feature.