### PR TITLE
Get all tests to pass in IE8

### DIFF
--- a/ext/css.js
+++ b/ext/css.js
@@ -48,9 +48,9 @@ if(loader.env === 'production') {
 				head.appendChild(style);
 
 				if(loader.has("live-reload")) {
-					var cssReload = loader.import("live-reload", { name: "$css" });
+					var cssReload = loader["import"]("live-reload", { name: "$css" });
 					Promise.resolve(cssReload).then(function(reload){
-						loader.import(load.name).then(function(){
+						loader["import"](load.name).then(function(){
 							reload.once(load.name, function(){
 								head.removeChild(style);
 							});

--- a/ext/npm.js
+++ b/ext/npm.js
@@ -300,9 +300,9 @@ var translateConfig = function(loader, packages){
 		}
 	};
 	var setupLiveReload = function(){
-		var hasLiveReload = !!loader._liveMap;
+		var hasLiveReload = !!(loader.liveReloadInstalled || loader._liveMap);
 		if(hasLiveReload) {
-			loader.import("live-reload", { name: module.id }).then(function(reload){
+			loader["import"]("live-reload", { name: module.id }).then(function(reload){
 				reload.dispose(function(){
 					// Remove state created by the config.
 					delete loader.npm;

--- a/main.js
+++ b/main.js
@@ -747,14 +747,14 @@ var makeSteal = function(System){
 		return appDeferred;
 	};
 
-	steal.import = function(){
+	steal["import"] = function(){
 		var names = arguments;
 		var loader = this.System;
 
 		function afterConfig(){
 			var imports = [];
 			each(names, function(name){
-				imports.push(loader.import(name));
+				imports.push(loader["import"](name));
 			});
 			if(imports.length > 1) {
 				return Promise.all(imports);
@@ -766,7 +766,7 @@ var makeSteal = function(System){
 		if(!configDeferred) {
 			steal.startup();
 		}
-		
+
 		return configDeferred.then(afterConfig);
 	};
 	return steal;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "system-json": "^0.0.3"
   },
   "devDependencies": {
-    "steal-css": "^0.0.4",
+    "steal-css": "^0.0.5",
     "steal-less": "^0.0.1",
     "system-npm": "^0.3.2",
     "system-live-reload": "^0.1.1",
@@ -32,7 +32,7 @@
     "grunt-release": "^0.7.0",
     "grunt-simple-mocha": "^0.4.0",
     "testee": "0.1.1",
-    "jquery": ">2.0",
+    "jquery": "^1.11.0",
     "babel-core": "5.8.14"
   },
   "system": {

--- a/src/import.js
+++ b/src/import.js
@@ -1,11 +1,11 @@
-	steal.import = function(){
+	steal["import"] = function(){
 		var names = arguments;
 		var loader = this.System;
 
 		function afterConfig(){
 			var imports = [];
 			each(names, function(name){
-				imports.push(loader.import(name));
+				imports.push(loader["import"](name));
 			});
 			if(imports.length > 1) {
 				return Promise.all(imports);
@@ -17,7 +17,7 @@
 		if(!configDeferred) {
 			steal.startup();
 		}
-		
+
 		return configDeferred.then(afterConfig);
 	};
 	return steal;

--- a/steal.js
+++ b/steal.js
@@ -5707,14 +5707,14 @@ if (typeof System !== "undefined") {
 		return appDeferred;
 	};
 
-	steal.import = function(){
+	steal["import"] = function(){
 		var names = arguments;
 		var loader = this.System;
 
 		function afterConfig(){
 			var imports = [];
 			each(names, function(name){
-				imports.push(loader.import(name));
+				imports.push(loader["import"](name));
 			});
 			if(imports.length > 1) {
 				return Promise.all(imports);
@@ -5726,7 +5726,7 @@ if (typeof System !== "undefined") {
 		if(!configDeferred) {
 			steal.startup();
 		}
-		
+
 		return configDeferred.then(afterConfig);
 	};
 	return steal;

--- a/test/basics/basics.html
+++ b/test/basics/basics.html
@@ -1,5 +1,6 @@
+<!doctype html>
+<html>
 <body>
-	
 
 <script>
 	window.QUnit = window.parent.QUnit;
@@ -7,3 +8,4 @@
 </script>
 <script type="text/javascript" src='../../steal.js' main='basics/basics' data-config="../config.js"></script>
 </body>
+</html>

--- a/test/bower/as_config/main.js
+++ b/test/bower/as_config/main.js
@@ -1,5 +1,5 @@
 
-System.import("jquerty").then(function($) {
+System["import"]("jquerty").then(function($) {
 
 	if(typeof window !== "undefined" && window.QUnit) {
 		QUnit.equal($, "jquerty", "Grabbed the correct module");

--- a/test/bower/main.js
+++ b/test/bower/main.js
@@ -1,5 +1,5 @@
 
-System.import("lodash").then(function(_) {
+System["import"]("lodash").then(function(_) {
 
 	if(typeof window !== "undefined" && window.QUnit) {
 		QUnit.ok(_, "Got lodash");

--- a/test/bower/with_paths/main.js
+++ b/test/bower/with_paths/main.js
@@ -1,5 +1,5 @@
 
-System.import("lodash").then(function(_) {
+System["import"]("lodash").then(function(_) {
 
 	if(typeof window !== "undefined" && window.QUnit) {
 		QUnit.equal(_.myModule, "lodash", "Grabbed the correct lodash");

--- a/test/current-steal/main.js
+++ b/test/current-steal/main.js
@@ -1,4 +1,4 @@
-import mySteal from '@steal';
+var mySteal = require('@steal');
 
 if(typeof window !== "undefined" && window.QUnit) {
 

--- a/test/dep_plugins/main.js
+++ b/test/dep_plugins/main.js
@@ -1,4 +1,4 @@
-import 'dep_plugins/main.less!';
+require('dep_plugins/main.less!');
 
 if(typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(document.getElementById("test-element").clientWidth, 200, "element width set by css");

--- a/test/envs/prod/dist/bundles/foo.js
+++ b/test/envs/prod/dist/bundles/foo.js
@@ -11,7 +11,7 @@ loader.config({
 	}
 });
 });
-System.define("jquerty","var jQuerty = {name: 'jQuerty'}")
+System.define("jquerty","window.jQuerty = {name: 'jQuerty'}")
 define("bar", ["jquerty"],function(jquerty){
 	return {
 		name: "bar",

--- a/test/ext/css.js
+++ b/test/ext/css.js
@@ -48,9 +48,9 @@ if(loader.env === 'production') {
 				head.appendChild(style);
 
 				if(loader.has("live-reload")) {
-					var cssReload = loader.import("live-reload", { name: "$css" });
+					var cssReload = loader["import"]("live-reload", { name: "$css" });
 					Promise.resolve(cssReload).then(function(reload){
-						loader.import(load.name).then(function(){
+						loader["import"](load.name).then(function(){
 							reload.once(load.name, function(){
 								head.removeChild(style);
 							});

--- a/test/ext/npm.js
+++ b/test/ext/npm.js
@@ -300,9 +300,9 @@ var translateConfig = function(loader, packages){
 		}
 	};
 	var setupLiveReload = function(){
-		var hasLiveReload = !!loader._liveMap;
+		var hasLiveReload = !!(loader.liveReloadInstalled || loader._liveMap);
 		if(hasLiveReload) {
-			loader.import("live-reload", { name: module.id }).then(function(reload){
+			loader["import"]("live-reload", { name: module.id }).then(function(reload){
 				reload.dispose(function(){
 					// Remove state created by the config.
 					delete loader.npm;

--- a/test/extensions/main.js
+++ b/test/extensions/main.js
@@ -1,15 +1,14 @@
-import 'extensions/main.less!';
-import 'extensions/main.css!';
-import text from 'extensions/hello.txt!';
-import crazy from 'extensions/hello.crazy!';
-
+require('extensions/main.less!');
+require('extensions/main.css!');
+var text = require('extensions/hello.txt!');
+var crazy = require('extensions/hello.crazy!');
 
 if(typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(text, 'hello world', "text loaded from the .txt file");
 	QUnit.equal(crazy, 'hello crazy', "text loaded from the .crazy file");
 	QUnit.equal(document.getElementById("test-element1").clientWidth, 200, "element width set by css");
 	QUnit.equal(document.getElementById("test-element2").clientWidth, 200, "element width set by css");
-	
+
 	QUnit.start();
 	removeMyself();
 } else {

--- a/test/forward_slash/folder/folder.js
+++ b/test/forward_slash/folder/folder.js
@@ -1,1 +1,1 @@
-export var foo = "bar";
+exports.foo = "bar";

--- a/test/forward_slash/folder/foo/bar/bar.js
+++ b/test/forward_slash/folder/foo/bar/bar.js
@@ -1,1 +1,1 @@
-export var baz = "end";
+exports.baz = "end";

--- a/test/forward_slash/folder/foo/foo.js
+++ b/test/forward_slash/folder/foo/foo.js
@@ -1,1 +1,1 @@
-export var bar = "baz";
+exports.bar = "baz";

--- a/test/forward_slash/main.js
+++ b/test/forward_slash/main.js
@@ -1,6 +1,6 @@
-import { foo } from "forward_slash/folder/";
-import { bar } from "forward_slash/folder/foo/"
-import { baz } from "forward_slash/folder/foo/bar/"
+var foo = require("forward_slash/folder/").foo;
+var bar = require("forward_slash/folder/foo/").bar;
+var baz = require("forward_slash/folder/foo/bar/").baz;
 
 if (typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(foo, "bar", "value set in folder module");

--- a/test/json/main.js
+++ b/test/json/main.js
@@ -1,4 +1,4 @@
-import my from "json/my.json";
+var my = require("json/my.json");
 
 if (typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(my.foo,"bar", "module returned" );

--- a/test/load-bundles/dist/bundles/foo.js
+++ b/test/load-bundles/dist/bundles/foo.js
@@ -7,7 +7,7 @@ loader.config({
 	}
 });
 });
-System.define("jquerty","var jQuerty = {name: 'jQuerty'}")
+System.define("jquerty","window.jQuerty = {name: 'jQuerty'}")
 define("bar", ["jquerty"],function(jquerty){
 	return {
 		name: "bar",
@@ -18,10 +18,10 @@ define("foo",["bar"], function(bar){
 	if(typeof window !== "undefined" && window.QUnit) {
 		QUnit.ok(bar, "got basics/module");
 		QUnit.equal(bar.name, "bar", "module name is right");
-		
+
 		QUnit.equal(bar.jquerty.name, "jQuerty", "got global");
-		
-		
+
+
 		QUnit.start();
 		removeMyself();
 		return {};

--- a/test/npm-deep/main.js
+++ b/test/npm-deep/main.js
@@ -1,4 +1,4 @@
-import name from "some/mod/";
+var name = require("some/mod/");
 
 if (typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(name, "mod", "got a npm module using the forward slash extension" );

--- a/test/npm/alt.js
+++ b/test/npm/alt.js
@@ -1,4 +1,4 @@
-import $ from "jquery";
+var $ = require("jquery");
 
 if (typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(typeof $,"function", "got jQuery" );

--- a/test/npm/main.js
+++ b/test/npm/main.js
@@ -1,4 +1,4 @@
-import $ from "jquery";
+var $ = require("jquery");
 
 if (typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(typeof $,"function", "got jQuery" );

--- a/test/plugins/main.js
+++ b/test/plugins/main.js
@@ -1,5 +1,5 @@
-import 'plugins/main.css!';
-import './steal-module';
+require('plugins/main.css!');
+require('./steal-module');
 
 if(typeof window !== "undefined" && window.QUnit) {
 	QUnit.equal(document.getElementById("test-element").clientWidth, 200, "element width set by css");

--- a/test/prod-bundlesPath/bundles/foo.js
+++ b/test/prod-bundlesPath/bundles/foo.js
@@ -5,7 +5,7 @@ steal.config({
 		}
 	}
 });
-System.define("jquerty","var jQuerty = {name: 'jQuerty'}")
+System.define("jquerty","window.jQuerty = {name: 'jQuerty'}")
 define("bar", ["jquerty"],function(jquerty){
 	return {
 		name: "bar",
@@ -16,10 +16,10 @@ define("foo",["bar"], function(bar){
 	if(typeof window !== "undefined" && window.QUnit) {
 		QUnit.ok(bar, "got basics/module");
 		QUnit.equal(bar.name, "bar", "module name is right");
-		
+
 		QUnit.equal(bar.jquerty.name, "jQuerty", "got global");
-		
-		
+
+
 		QUnit.start();
 		removeMyself();
 		return {};

--- a/test/prod_define/dist/bundles/index.js
+++ b/test/prod_define/dist/bundles/index.js
@@ -65,13 +65,13 @@ define('stealconfig.js', function(require, exports, module) {
 define('index', function(require, exports, module) {
 "format cjs";
 
-System.import('components/page1')
+System["import"]('components/page1')
     .then(function() {
 		if(typeof window !== "undefined" && window.QUnit) {
 			QUnit.ok(true, "Loaded page 1");
 			QUnit.equal(window.jqwerty.modName, "jqwerty", "jqwerty loaded");
 			QUnit.equal(typeof window.jqwerty.ui, "function", "jqwertyui loaded");
-			
+
 			QUnit.start();
 			removeMyself();
 			return {};
@@ -80,7 +80,7 @@ System.import('components/page1')
 			console.assert(window.jqwerty.modName == "jqwerty");
 		}
     })
-    .catch(function(ex) {
+    ["catch"](function(ex) {
 		if(typeof window !== "undefined" && window.QUnit) {
 			QUnit.ok(false, "Unable to load page 1");
 

--- a/test/prod_define/dist/bundles/page1-page2.js
+++ b/test/prod_define/dist/bundles/page1-page2.js
@@ -1,5 +1,5 @@
 /*jqwerty*/
-System.define('jqwerty','jQwerty = function(){};\njQwerty.modName = "jqwerty";\n',{"address":"jqwerty","metadata":{"exports":"jQwerty","deps":[],"format":"global"}});
+System.define('jqwerty','window.jQwerty = function(){};\njQwerty.modName = "jqwerty";\n',{"address":"jqwerty","metadata":{"exports":"jQwerty","deps":[],"format":"global"}});
 /*jqwertyui*/
 define('jqwertyui', ['jqwerty'], function ($) {
     $.ui = function () {

--- a/test/production/dist/bundles/foo.js
+++ b/test/production/dist/bundles/foo.js
@@ -7,7 +7,7 @@ loader.config({
 	}
 });
 });
-System.define("jquerty","var jQuerty = {name: 'jQuerty'}")
+System.define("jquerty","window.jQuerty = {name: 'jQuerty'}")
 define("bar", ["jquerty"],function(jquerty){
 	return {
 		name: "bar",
@@ -18,10 +18,10 @@ define("foo",["bar"], function(bar){
 	if(typeof window !== "undefined" && window.QUnit) {
 		QUnit.ok(bar, "got basics/module");
 		QUnit.equal(bar.name, "bar", "module name is right");
-		
+
 		QUnit.equal(bar.jquerty.name, "jQuerty", "got global");
-		
-		
+
+
 		QUnit.start();
 		removeMyself();
 		return {};

--- a/test/test.html
+++ b/test/test.html
@@ -4,23 +4,23 @@
 		<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
 	</head>
 	<body>
-		
+
 		<h1 id="qunit-header">Steal Test Suite</h1>
-		
+
 		<h2 id="qunit-banner"></h2>
 		<div id="qunit-testrunner-toolbar"></div>
 		<h2 id="qunit-userAgent"></h2>
 		<ol id="qunit-tests"></ol>
 		<div id="qunit-test-area"></div>
-		
+
 		<script src="../bower_components/es6-module-loader/dist/es6-module-loader.src.js" type="text/javascript"></script>
 		<script src="../bower_components/systemjs/dist/system.src.js" data-traceur-src="../bower_components/traceur/traceur.js" type="text/javascript"></script>
 		<script src="../system-format-steal.js"></script>
 		<script src="../bower_components/qunit/qunit/qunit.js"></script>
-		
+
 		<script src="test.js"></script>
     <script>
-      delete window.define;
+      //delete window.define;
     </script>
 	</body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -4,10 +4,25 @@ QUnit.config.testTimeout = 30000;
 
 (function(){
 
+	// Legacy IE doesn't support reserved keywords and Traceur uses them
+	// so using this as an easy way to feature-detect browser support for
+	// ES6 transpilers.
+	var supportsES = (function(){
+		try {
+			eval("var foo = { typeof: 'typeof' };");
+			return true;
+		} catch(e) {
+			return false;
+		}
+	})();
+
 	var writeIframe = function(html){
 		var iframe = document.createElement('iframe');
 		window.removeMyself = function(){
-			delete window.removeMyself;
+			window.removeMyself = undefined;
+			try {
+				delete window.removeMyself;
+			} catch(e) {}
 			document.body.removeChild(iframe);
 		};
 		document.body.appendChild(iframe);
@@ -37,7 +52,10 @@ QUnit.config.testTimeout = 30000;
 	var makeIframe = function(src){
 		var iframe = document.createElement('iframe');
 		window.removeMyself = function(){
-			delete window.removeMyself;
+			window.removeMyself = undefined;
+			try {
+				delete window.removeMyself;
+			} catch(e) {}
 			document.body.removeChild(iframe);
 		};
 		document.body.appendChild(iframe);
@@ -124,56 +142,62 @@ QUnit.config.testTimeout = 30000;
 
 	module("steal via html");
 
-	asyncTest("basics", function(){
-		makeIframe("basics/basics.html");
-	});
+	if(supportsES) {
+		asyncTest("basics", function(){
+			makeIframe("basics/basics.html");
+		});
 
-	asyncTest("basics with steal.config backwards compatability", function(){
-		makeIframe("basics/basics-steal-config.html");
-	});
+		asyncTest("basics with steal.config backwards compatability", function(){
+			makeIframe("basics/basics-steal-config.html");
+		});
 
 
-	asyncTest("basics with generated html", function(){
-		writeIframe(makeStealHTML(
-			"basics/basics.html",
-			'src="../../steal.js?basics" data-config="../config.js"'));
-	});
+		asyncTest("basics with generated html", function(){
+			writeIframe(makeStealHTML(
+				"basics/basics.html",
+				'src="../../steal.js?basics" data-config="../config.js"'));
+		});
 
-	asyncTest("default config path", function(){
-		writeIframe(makeStealHTML(
-			"basics/basics.html",
-			'src="../steal.js?basics"'));
-	});
+		asyncTest("default config path", function(){
+			writeIframe(makeStealHTML(
+				"basics/basics.html",
+				'src="../steal.js?basics"'));
+		});
 
-	asyncTest("default config path", function(){
-		writeIframe(makeStealHTML(
-			"basics/basics.html",
-			'src="../steal/steal.js?basics"'));
-	});
+		asyncTest("default config path", function(){
+			writeIframe(makeStealHTML(
+				"basics/basics.html",
+				'src="../steal/steal.js?basics"'));
+		});
+	}
 
 	asyncTest("inline", function(){
 		makeIframe("basics/inline_basics.html");
 	});
 
-	asyncTest("default bower_components config path", function(){
-		writeIframe(makeStealHTML(
-			"basics/basics.html",
-			'src="../bower_components/steal/steal.js?basics"'));
-	});
+	if(supportsES) {
+		asyncTest("default bower_components config path", function(){
+			writeIframe(makeStealHTML(
+				"basics/basics.html",
+				'src="../bower_components/steal/steal.js?basics"'));
+		});
 
-	asyncTest("default bower_components without config still works", function(){
-		makeIframe("basics/noconfig.html");
-	});
+		asyncTest("default bower_components without config still works", function(){
+			makeIframe("basics/noconfig.html");
+		});
+	}
 
 	asyncTest("map works", function(){
 		makeIframe("map/map.html");
 	});
 
-	asyncTest("read config", function(){
-		writeIframe(makeStealHTML(
-			"basics/basics.html",
-			'src="../../steal.js?configed" data-config="../config.js"'));
-	});
+	if(supportsES) {
+		asyncTest("read config", function(){
+			writeIframe(makeStealHTML(
+				"basics/basics.html",
+				'src="../../steal.js?configed" data-config="../config.js"'));
+		});
+	}
 
 	asyncTest("compat - production bundle works", function(){
 		makeIframe("production/prod.html");
@@ -199,24 +223,26 @@ QUnit.config.testTimeout = 30000;
 		makeIframe("production/prod-bar.html");
 	});
 
-	asyncTest("automatic loading of less plugin", function(){
-		makeIframe("dep_plugins/site.html");
-	});
-
-
 	asyncTest("Using path's * qualifier", function(){
 		writeIframe(makeStealHTML(
 			"basics/basics.html",
 			'src="../steal.js?../paths" data-config="../paths/config.js"'));
 	});
 
-	asyncTest("url paths in less work", function(){
-		makeIframe("less_paths/site.html");
-	});
+	// Less doesn't work in ie8
+	if(supportsES) {
+		asyncTest("automatic loading of less plugin", function(){
+			makeIframe("dep_plugins/site.html");
+		});
 
-	asyncTest("ext extension", function(){
-		makeIframe("extensions/site.html");
-	});
+		asyncTest("url paths in less work", function(){
+			makeIframe("less_paths/site.html");
+		});
+
+		asyncTest("ext extension", function(){
+			makeIframe("extensions/site.html");
+		});
+	}
 
 	asyncTest("forward slash extension", function(){
 		makeIframe("forward_slash/site.html");
@@ -226,7 +252,7 @@ QUnit.config.testTimeout = 30000;
 		makeIframe("configed/steal_object.html");
 	});
 
-	asyncTest("compat - product bundle works", function(){
+	asyncTest("compat - production bundle works", function(){
 		makeIframe("prod-bundlesPath/prod.html");
 	});
 
@@ -242,9 +268,12 @@ QUnit.config.testTimeout = 30000;
 		makeIframe("current-loader/dev.html");
 	});
 
-	asyncTest("@loader is current loader with es6", function(){
-		makeIframe("current-loader/dev-es6.html");
-	});
+	if(supportsES) {
+		asyncTest("@loader is current loader with es6", function(){
+			makeIframe("current-loader/dev-es6.html");
+		});
+	}
+
 	asyncTest("@loader is current loader with steal syntax", function(){
 		makeIframe("current-loader/dev-steal.html");
 	});
@@ -262,13 +291,15 @@ QUnit.config.testTimeout = 30000;
 		makeIframe("basics/truthy_script_options.html");
 	});
 
-	asyncTest("using babel as transpiler works", function(){
-		makeIframe("babel/site.html");
-	});
+	if(supportsES) {
+		asyncTest("using babel as transpiler works", function(){
+			makeIframe("babel/site.html");
+		});
 
-	asyncTest("inline code", function(){
-		makeIframe("basics/inline_code.html");
-	});
+		asyncTest("inline code", function(){
+			makeIframe("basics/inline_code.html");
+		});
+	}
 
 	asyncTest("can load a bundle with an amd module depending on a global", function(){
 		makeIframe("prod_define/prod.html");
@@ -298,9 +329,12 @@ QUnit.config.testTimeout = 30000;
 		makeIframe("npm/alt-main.html");
 	});
 
-	asyncTest("production", function(){
-		makeIframe("npm/prod.html");
-	});
+	// This test uses jQuery 2.x
+	if(supportsES) {
+		asyncTest("production", function(){
+			makeIframe("npm/prod.html");
+		});
+	}
 
 	asyncTest("with bower", function(){
 		makeIframe("npm/bower/index.html");


### PR DESCRIPTION
This fixes our IE8 compatibility. There were a few uses of `loader.import` rather
than `loader["import"]`.