### PR TITLE
Update system-npm for npm3 support

### DIFF
--- a/docs/module-npm.md
+++ b/docs/module-npm.md
@@ -18,7 +18,9 @@ By default, if [System.stealPath] points to steal.js within node_modules like:
     <script src="../node_modules/steal/steal.js"></script>
     
 [System.configMain] will point to `"package.json!npm"`. The `npm` plugin
-reads `package.json` and sets a normalize and locate hook.  
+reads `package.json` and sets a normalize and locate hook.
+
+**Note**: if you are using NPM 3 see the *npmAlgorithm* option below.
 
 
 ## NPM Module names
@@ -33,9 +35,7 @@ For example, code that import's jQuery like:
 
 might actually import:
 
-    jquery@2.1.3#./dist/jquery.js
-
-
+    jquery@2.1.3#dist/jquery.js
 
 ## Configuration
 
@@ -174,7 +174,7 @@ The following packages are ignored by default:
  - "bower"
  - "grunt", "grunt-cli"
 
-### system.npm.npmDependencies
+### package.system.npmDependencies
 
 Like `npmIgnore` but affirmative. If used alone will only include the dependencies listed. If used in conjunction with `npmIgnore` acts as an override. For example the following config:
 
@@ -210,7 +210,19 @@ When used in conjuction with `npmIgnore`:
 
 Even though `npmIgnore` is set to ignore all `devDependencies` the use of `npmDependencies` acts as an override. The package `one` will be loaded, but not `two` or `three`.
 
-### system.npm.ignoreBrowser
+### package.system.npmAlgorithm
+
+Used to determine which algorithm is used to look up packages. [NPM 3](http://blog.npmjs.org/post/122450408965/npm-weekly-20-npm-3-is-here-ish) introduced a new flat file structure inside node_modules. If you are using NPM 3 set this option:
+
+```js
+{
+  "system": {
+    "npmAlgorithm": "flat"
+  }
+}
+```
+
+### package.system.ignoreBrowser
 
 Set to true to ignore browserfy's `browser` and `browserify` configurations.
 
@@ -222,7 +234,7 @@ Set to true to ignore browserfy's `browser` and `browserify` configurations.
 }
 ```
 
-### system.npm.directories
+### package.system.directories
 
 Set a folder to look for module's within your project.  Only the `lib` 
 directory can be specified.
@@ -241,7 +253,7 @@ In the following setup, `my-project/my-utils` will be looked for in
 }
 ```
 
-### system.npm.configDependencies
+### package.system.configDependencies
 
 Defines dependencies of your npm package. This is useful for loading modules,
 like extensions, that need to be initialized before the rest of your application

--- a/docs/pages/quick-start.md
+++ b/docs/pages/quick-start.md
@@ -62,13 +62,15 @@ The `index.html` loads your app. The following `script src` loads `steal.js` and
 Steal uses `package.json` to configure its behavior. Find the full details on
 the [npm npm extension page]. Most of the configuration happens within
 a special "system" property. Its worth creating it now in case you'll
-need it later.
+need it later. If you are using NPM 3 also set the npmAlgorithm option within the system property, otherwise leave it out.
 
 ```
 // package.json
 {
   ...
-  "system": {},
+  "system": {
+	"npmAlgorithm": "flat"
+  },
   ...
 }
 ```

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -3,20 +3,6 @@
 
 Here's what we've got planned:
 
-## Watch Builds
-
-Automatically build when a file changes. We should be able to make
-this extremely high performance if the dependency graph is not changing.
-
-## Live Reloading
-
-Would make development extremely convenient as modules would automatically
-reload as you change them without needing to reload the browser.
-
-## Remove Traceur Runtime and IE8 ES6 module support
-
-[Read here](https://groups.google.com/forum/#!topic/systemjs/yECCl6I9SDw) 
-
 ## Development Packages
 
 Build a package that will be loaded in development. For example, instead of

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -107,7 +107,7 @@ exports.addExtension = function(System){
 			loader = this;
 		// @ is not the first character
 		if(parsedModuleName.version && this.npm && !loader.paths[load.name]) {
-			var pkg = this.npm[parsedModuleName.packageName];
+			var pkg = this.npm[utils.moduleName.nameAndVersion(parsedModuleName)];
 			if(pkg) {
 				return oldLocate.call(this, load).then(function(address){
 					var expectedAddress = utils.path.joinURIs(

--- a/ext/npm.js
+++ b/ext/npm.js
@@ -4,14 +4,10 @@
 var utils = require('./npm-utils');
 var crawl = require('./npm-crawl');
 
-
 // Add @loader, for SystemJS
 if(!System.has("@loader")) {
 	System.set('@loader', System.newModule({'default':System, __useDefault: true}));
 }
-
-
-
 
 // SYSTEMJS PLUGIN EXPORTS =================
 
@@ -38,8 +34,10 @@ exports.translate = function(load){
 		versions: {}
 	};
 	var pkg = {origFileUrl: load.address, fileUrl: load.address};
-
 	crawl.processPkgSource(context, pkg, load.source);
+	if(pkg.system && pkg.system.npmAlgorithm === "flat") {
+		context.isFlatFileStructure = true;
+	}
 
 	return crawl.deps(context, pkg, true).then(function(){
 		// clean up packages so everything is unique

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "steal-css": "^0.0.5",
     "steal-less": "^0.0.1",
-    "system-npm": "0.3.7",
+    "system-npm": "0.4.0",
     "system-live-reload": "1.4.0",
     "system-trace": "0.1.7",
     "bower": "1.3.8",

--- a/test/ext/npm.js
+++ b/test/ext/npm.js
@@ -4,14 +4,10 @@
 var utils = require('./npm-utils');
 var crawl = require('./npm-crawl');
 
-
 // Add @loader, for SystemJS
 if(!System.has("@loader")) {
 	System.set('@loader', System.newModule({'default':System, __useDefault: true}));
 }
-
-
-
 
 // SYSTEMJS PLUGIN EXPORTS =================
 
@@ -38,8 +34,10 @@ exports.translate = function(load){
 		versions: {}
 	};
 	var pkg = {origFileUrl: load.address, fileUrl: load.address};
-
 	crawl.processPkgSource(context, pkg, load.source);
+	if(pkg.system && pkg.system.npmAlgorithm === "flat") {
+		context.isFlatFileStructure = true;
+	}
 
 	return crawl.deps(context, pkg, true).then(function(){
 		// clean up packages so everything is unique


### PR DESCRIPTION
This updates system-npm for npm3 support. Adds docs to the npm module explaining usage of `npmAlgorithm` to turn on npm3 support:

```json
{
  "system": {
    "npmAlgorithm": "flat"
  }
}
```

Closes #521 