### PR TITLE
Upgrade to steal-css 0.1.1

### DIFF
--- a/ext/css.js
+++ b/ext/css.js
@@ -1,6 +1,6 @@
 var loader = require("@loader");
 
-if(loader.isEnv("production")) {
+if(isProduction()) {
 	exports.fetch = function(load) {
 		// return a thenable for fetching (as per specification)
 		// alternatively return new Promise(function(resolve, reject) { ... })
@@ -64,6 +64,11 @@ if(loader.isEnv("production")) {
 		load.metadata.format = "css";
 	};
 
+}
+
+function isProduction(){
+	return (loader.isEnv && loader.isEnv("production")) ||
+		loader.env === "production";
 }
 
 exports.buildType = "css";

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "system-json": "^0.0.3"
   },
   "devDependencies": {
-    "steal-css": "^0.1.0",
+    "steal-css": "0.1.1",
     "steal-less": "^0.0.1",
     "system-npm": "0.3.7",
     "system-live-reload": "1.4.0",

--- a/test/ext/css.js
+++ b/test/ext/css.js
@@ -1,6 +1,6 @@
 var loader = require("@loader");
 
-if(loader.isEnv("production")) {
+if(isProduction()) {
 	exports.fetch = function(load) {
 		// return a thenable for fetching (as per specification)
 		// alternatively return new Promise(function(resolve, reject) { ... })
@@ -64,6 +64,11 @@ if(loader.isEnv("production")) {
 		load.metadata.format = "css";
 	};
 
+}
+
+function isProduction(){
+	return (loader.isEnv && loader.isEnv("production")) ||
+		loader.env === "production";
 }
 
 exports.buildType = "css";


### PR DESCRIPTION
This version includes a check that `loader.isEnv` exists because the CSS plugin might be used by a project that is exported into a global (with steal-tools) in which case there is only a tiny loader shim that doesn't include isEnv.