### PR TITLE
No main warning if steal is bundled

### DIFF
--- a/main.js
+++ b/main.js
@@ -1071,7 +1071,7 @@ function addEnv(loader){
 		// we only load things with force = true
 		if ( System.loadBundles ) {
 
-			if(!System.main && System.isEnv("production")) {
+			if(!System.main && System.isEnv("production") && !System.stealBundled) {
 				// prevent this warning from being removed by Uglify
 				var warn = console && console.warn || function() {};
 				warn.call(console, "Attribute 'main' is required in production environment. Please add it to the script tag.");

--- a/src/startup.js
+++ b/src/startup.js
@@ -63,7 +63,7 @@
 		// we only load things with force = true
 		if ( System.loadBundles ) {
 
-			if(!System.main && System.isEnv("production")) {
+			if(!System.main && System.isEnv("production") && !System.stealBundled) {
 				// prevent this warning from being removed by Uglify
 				var warn = console && console.warn || function() {};
 				warn.call(console, "Attribute 'main' is required in production environment. Please add it to the script tag.");

--- a/steal.js
+++ b/steal.js
@@ -6104,7 +6104,7 @@ function addEnv(loader){
 		// we only load things with force = true
 		if ( System.loadBundles ) {
 
-			if(!System.main && System.isEnv("production")) {
+			if(!System.main && System.isEnv("production") && !System.stealBundled) {
 				// prevent this warning from being removed by Uglify
 				var warn = console && console.warn || function() {};
 				warn.call(console, "Attribute 'main' is required in production environment. Please add it to the script tag.");


### PR DESCRIPTION
if we are in production and dont added a `main` attribute to the script tag, we get a warning.
but the `main` is not needed if we have steal bundled with steal-tools `stealBundle = true`

this PR prevent to get a warning.
we can use this new feature to detect if steal is bundled in the file https://github.com/stealjs/steal-tools/pull/425

close #641