### PR TITLE
Adds a test that shows imports rejecting in Node

### DIFF
--- a/test/node_test.js
+++ b/test/node_test.js
@@ -43,3 +43,24 @@ describe("plugins", function(){
 	});
 
 });
+
+describe("Modules that don't exist", function(){
+	it("should reject", function(done){
+		var steal = makeSteal({
+			config: __dirname + "/../package.json!npm",
+			main: "@empty"
+		});
+
+		steal.startup().then(function(){
+			var System = steal.System;
+
+			System.import("some/fake/module")
+			.then(function(){
+				assert.ok(false, "Promise resolved when it should have rejected");
+			}, function(err){
+				assert.ok(err instanceof Error, "Got an error");
+			})
+			.then(done, done);
+		});
+	});
+});


### PR DESCRIPTION
This adds a test that shows that when a module is imported that doesn't exist in the filesystem in Node, that import promise will be rejected.