### PR TITLE
Add a guide on configuration

### DIFF
--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -1,0 +1,125 @@
+@page StealJS.configuration Configuration
+@parent StealJS.guides
+
+@body
+
+Steal allows you to configure module loading through a **system** property in your package.json. If you're not using Steal through NPM (you should be) you can also configure using any of the options provided by [System.config].
+
+A basic configuration might look like this:
+
+```
+{
+  ...
+  "system": {
+    "meta": {
+	  "jquery-plugin": {
+        "deps": ["jquery"]
+      }
+	},
+	"paths": {
+      "some-dep": "lib/some/dep.js"
+	}
+  }
+}
+```
+
+Here are some common uses of configuration:
+
+## Configuring globals
+
+Many modules you find on the web only have a single global build and don't work with module loaders that support AMD or CommonJS. jQuery plugins often are built this way.
+
+To use these modules you need to configure them as globals. This is similar to **shim** config in RequireJS. Here's an example with each option explained:
+
+```
+{
+  "dependencies": {
+    "jquery": "2.2.2",
+    "jquery-plugin": "0.2.0"
+  },
+
+  ...
+
+  "system": {
+    "meta": {
+      "jquery-plugin": {
+        "deps": ["jquery"],
+        "exports": "jQuery"
+      }
+    }
+  }
+}
+```
+
+### deps
+
+The [load.metadata meta] **deps** property is an Array that specifies the module's dependencies. In this example we are saying that this module `jquery-plugin` depends on `jquery`.
+
+### exports
+
+The [load.metadata meta] **exports** property specifies a global value that is the module's value. For example if we had a module that did:
+
+```
+window.FOO = { ... };
+```
+
+We would specify this config with: `"exports": "FOO"`.  Then any other module that exports it like:
+
+```
+import foo from "foo";
+```
+
+Will get the `FOO` global.
+
+## Progressively loaded bundles
+
+In the [steal-tools.guides.progressive_loading progressive loading guide] we show how to progressively load different pages within your app. You import these modules using the [System.import] function like so:
+
+```
+System.import("app/cart").then(function(cart){
+
+});
+```
+
+When using [steal-tools] to do a production build it needs to know about these progressively loaded bundles in order to perform its code splitting algorithm.
+
+You can specify your bundles with the **bundle** property in config:
+
+```
+{
+  ...
+  "system": {
+    "bundle": [
+      "app/cart"
+	]
+  }
+}
+```
+
+Then when you perform a build it will create a bundle in `dist/bundles/app/cart.js` by default (you can specify the path using [System.bundlesPath bundlesPath] configuration).
+
+## Specify your project's root folder
+
+Often projects will store their code in a subfolder like `src/` or `public/` and do not want to include that when importing modules. Using **directories.lib** configuration you can specify your project's root folder:
+
+```
+{
+  "name": "app",
+
+  ...
+
+  "system": {
+    "directories": {
+      "lib": "src"
+    }
+  }
+}
+```
+
+Then you can import modules from this folder by preceding imports with your package name like:
+
+```
+import util from "app/util";
+```
+
+*Note* that you cannot omit the package name when importing a module unless you use relative paths like `"./util"`.

--- a/docs/pages/migrating.md
+++ b/docs/pages/migrating.md
@@ -2,7 +2,9 @@
 @parent StealJS.guides
 
 
-## Migrating from old Steal
+## Migrating from Legacy Steal
+
+If you were a user of [legacy Steal](https://github.com/bitovi/legacy-steal) this guide is meant to help you upgrade to the modern version of Steal. If you've never heard of the legacy Steal, this page isn't for you.
 
 ### Config changes
 
@@ -56,7 +58,7 @@ The old Steal was chainable using `.then`, but this produced numerous problems t
 
 The old Steal always produced a `production.js` file, but this is no longer the case. Though configurable, by default the new Steal will place the production file in `dist/bundles` and it will be named after your main module.
 
-You will also need to add the following to your `stealconfig.js` file to be able to build the CanJS projects:
+You will also need to add the following to your `stealconfig.js` file to be able to build the CanJS projects (note if you are using NPM this isn't necessary):
 
     System.buildConfig = {
       map: {

--- a/docs/system-config.md
+++ b/docs/system-config.md
@@ -7,11 +7,37 @@ set properties like [System.configPath] and [System.env].
 
 @param {Object} config An object of configuration values.
 
+```
+System.config({
+  map: {
+    foo: 'bar'
+  }
+});
+```
+
 @body
 
 ## Use
 
-`System.config` can be called in three ways.  
+`System.config` can be called in four ways.
+
+### package.json
+
+If using the [npm] plugin you can add config to your package.json's **config** property:
+
+```
+{
+  "system": {
+    "meta": {
+      "jquery-plugin": {
+        "deps": [
+          "jquery"
+        ]
+      }
+    }
+  }
+}
+```
 
 ### Programatically
 
@@ -33,6 +59,15 @@ Any property besides src, id, and type will be used to set on System:
             main="app">
     </script>
 
+The above will be translated to a call like:
+
+```
+System.config({
+  configPath: "../path/to/stealconfig.js",
+  main: "app"
+});
+```
+
 ### steal object
 
 A `steal` object loaded before `steal.js` will be used as a System.config argument.
@@ -44,10 +79,3 @@ A `steal` object loaded before `steal.js` will be used as a System.config argume
       }
     </script>
     <script src="../path/to/steal/steal.js"></script>
-
-
-## Implementation
-
-Basic deep merging of configuration properties is done in [SystemJS](https://github.com/bitovi/systemjs).
-
-Side effect property setting is done by steal.


### PR DESCRIPTION
Added a guide that explains how to configure Steal in your package.json, and with some of the most common usages of Steal config.