### PR TITLE
Updating the @loader docs

### DIFF
--- a/docs/module-loader.md
+++ b/docs/module-loader.md
@@ -1,28 +1,29 @@
 @typedef {*} @loader
 @parent StealJS.modules
 
-`@loader` is primarily only needed to be used in your [@config] to ensure that you are configuring
-the correct loader. Since [System](steal#section_LoaderandSystemnamespaces) represents the global System loader using it within your
-config doesn't guarantee that you are configuring the correct loader. In scenarios where
-you want to build multiple apps in parallel, for example if you have several apps set
-up to build in a Grunt task, using `loader` is necessarily so that your [@config] options
-are set on the proper loader.
+**@loader** is a module that refers to the loader that is loading the module. Any time you need to configure the loader or dynamically import modules, it's best to use `@loader` rather than the global `System`.
 
-@option {*} The `@loader` module is the `Loader` that is loading your code.
+In most cases they are the same, but during the build there are multiple loaders; and if using [steal.steal-clone] to test injected modules.
+
+@option {*} The **@loader** module is the `Loader` that is loading your code.
 
 @body
 
 ## Use
 
-To use `@loader` simply import it into your config and use it in the same way you
+To use **@loader** simply import it and use it in the same way you
 would use [System](steal#section_LoaderandSystemnamespaces).
 
     import loader from "@loader";
 
-    loader.config({
-      map: {
-        "can/util/util": "can/util/jquery/jquery"
-      }
-    });
+	loader.config({
+		map: {
+			a: "b"
+		}
+	});
+
+	loader.import("someOtherModule").then(function(mod){
+
+	});
 
 This works with any syntax supported by StealJS.

--- a/docs/module-steal-clone.md
+++ b/docs/module-steal-clone.md
@@ -5,7 +5,7 @@ Steal-clone is a module that allows you to clone Steal's loader and provide modu
 
 @signature `clone(moduleOverrides)`
 
-@param {Object} moduleOverrides Module names and definitions used to override modules of the same name. These definitions will be used when importing parent modules using the `import` function of the returned loader.
+@param {Object} moduleOverrides Module identifiers and definitions used to override modules of the same name. These definitions will be used when importing parent modules using the `import` statement of the returned loader.
 
 @return {Object} The cloned loader.
 
@@ -47,9 +47,9 @@ clone({
 });
 ```
 
-### Module Names
+### Module Identifiers
 
-The keys passed in the `moduleOverrides` object ("moduleB" in the example above) can be any valid module name. All of the module syntaxes supported by Steal are supported by steal-clone. If you're using [ES6 modules](http://stealjs.com/docs/syntax.es6.html), you can use the same value used in your import statement. Similarly, if you're using [CommonJS](http://stealjs.com/docs/syntax.CommonJS.html), you can use the same value that you pass to 'require'.
+The keys passed in the `moduleOverrides` object ("moduleB" in the example above) can be any valid module identifier. All of the module syntaxes supported by Steal are supported by steal-clone. If you're using [ES6 modules](http://stealjs.com/docs/syntax.es6.html), you can use the same value used in your import statement. Similarly, if you're using [CommonJS](http://stealjs.com/docs/syntax.CommonJS.html), you can use the same value that you pass to 'require'.
 
 You can also use relative paths to override modules based on where you are using steal-clone:
 
@@ -91,6 +91,20 @@ clone({
   }
 });
 ```
+
+### Dynamically imported modules
+
+It's possible to provide overrides to modules that will be later dynamically imported. If you have a `moduleC` defined as:
+
+```js
+import loader from '@loader';
+
+loader.import('moduleB').then(function(){
+
+});
+```
+
+You will be able to override the value of `moduleB`. Note that for this to work you must import [@loader] to use for dynamic loading instead of using `System.import`. This is because `@loader` will refer to the cloned loader you created where as `System` always refers back to the global loader. Using [@loader] is always recommended anyways.
 
 ### Use with Bower or NPM
 


### PR DESCRIPTION
Updating the @loader docs; it's no longer true that it's used primarily by config. Since users don't write their own stealconfigs any more it's use can better be explained with regard to use with steal-clone.