### PR TITLE
Add test showing jsx is enabled by default

### DIFF
--- a/docs/system-babelOptions.md
+++ b/docs/system-babelOptions.md
@@ -7,12 +7,8 @@ Options that will be passed into Babel when compiling ES6 code. The options are 
 
 ## JSX
 
-Babel comes with support for transpiling JSX but it is not enabled by default in Steal. To enable the JSX support you can simply pass an empty array for the blacklist like so:
+JSX is supported by default, so you can use it directly in your code like:
 
 ```js
-System.config({
-  "babelOptions": {
-    "blacklist": []
-  }
-});
+export default <div>Hello <strong>world!</strong></div>;
 ```

--- a/test/jsx/dev.html
+++ b/test/jsx/dev.html
@@ -1,0 +1,5 @@
+<script>
+	window.QUnit = window.parent.QUnit;
+	window.removeMyself = window.parent.removeMyself;
+</script>
+<script src="../../steal.js" config="./package.json!npm"></script>

--- a/test/jsx/main.js
+++ b/test/jsx/main.js
@@ -1,0 +1,19 @@
+"format es6";
+
+// Shim it
+var React = {
+	createElement: function(){
+		return "it worked!";
+	}
+};
+
+var out = <div>Hello <strong>world!</strong></div>;
+
+if(typeof window !== "undefined" && window.QUnit) {
+	QUnit.equal(out, "it worked!", "transpiled jsx by default");
+
+	QUnit.start();
+	removeMyself();
+} else {
+	console.log("jsx loaded:", out);
+}

--- a/test/jsx/package.json
+++ b/test/jsx/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "jsx-app",
+	"version": "1.0.0",
+	"main": "main.js"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -169,6 +169,10 @@ QUnit.config.testTimeout = 30000;
 				"basics/basics.html",
 				'src="../steal/steal.js?basics"'));
 		});
+
+		asyncTest("jsx is enabled by default", function(){
+			makeIframe("jsx/dev.html");
+		});
 	}
 
 	asyncTest("inline", function(){


### PR DESCRIPTION
In 1.0.0 jsx will be enabled by default, this adds a test to verify that this is the case.

Closes #686