### PR TITLE
npm plugin always forces System.main to have package name

### DIFF
--- a/ext/npm-load.js
+++ b/ext/npm-load.js
@@ -77,14 +77,12 @@ exports.configDeps = function(context, pkg){
  */
 exports.pkgMain = function(context, pkg){
 	var pkgMain = utils.pkg.main(pkg);
-	// Convert the main if using directories.lib
-	if(utils.pkg.hasDirectoriesLib(pkg)) {
-		var mainHasPkg = pkgMain.indexOf(pkg.name) === 0;
-		if(mainHasPkg) {
-			pkgMain = convert.name(context, pkg, false, true, pkgMain);
-		} else {
-			pkgMain = convert.name(context, pkg, false, true, pkg.name+"/"+pkgMain);
-		}
+	// Convert the main
+	var mainHasPkg = pkgMain.indexOf(pkg.name) === 0;
+	if(mainHasPkg) {
+		pkgMain = convert.name(context, pkg, false, true, pkgMain);
+	} else {
+		pkgMain = convert.name(context, pkg, false, true, pkg.name+"/"+pkgMain);
 	}
 	return pkgMain;
 };

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "steal-less": "0.3.1",
     "system-bower": "stealjs/system-bower#v0.2.1",
     "system-live-reload": "1.5.2",
-    "system-npm": "1.0.0-pre.3",
+    "system-npm": "1.0.0-pre.7",
     "system-trace": "0.2.5",
     "testee": "^0.2.0",
     "traceur": "0.0.91",

--- a/test/bower/npm/package.json
+++ b/test/bower/npm/package.json
@@ -1,5 +1,7 @@
 {
+  "name": "bower-with-npm",
   "main": "main",
+  "version": "1.0.0",
   "dependencies": {
     "bar": ">2.0"
   }

--- a/test/npm/bower/package.json
+++ b/test/npm/bower/package.json
@@ -1,5 +1,7 @@
 {
+  "name": "npm-with-bower",
   "main": "main",
+  "version": "1.0.0",
   "dependencies": {
     "bar": ">2.0"
   },

--- a/test/npm/package.json
+++ b/test/npm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "npm-test",
+  "version": "1.0.0",
   "main": "main",
   "dependencies": {
     "jquery": ">1.10"


### PR DESCRIPTION
This is to fix inconsistencies and potential double-loading where package name is used some times, and some times not.