### PR TITLE
add docs for cssOptions

### DIFF
--- a/docs/system-cssOptions.md
+++ b/docs/system-cssOptions.md
@@ -1,0 +1,17 @@
+@property {Object} System.cssOptions
+@parent StealJS.config
+
+@option {Integer} timeout This specifies the time (in seconds) steal will try to load a css file, within a javascript module (e.g. `require('mycssfile.css')`, in __production mode__.
+```js
+System.config({
+    cssOptions: {
+        timeout: 15
+    }
+});
+```
+If no `timeout` is provided, the default value will be `60` seconds.
+Note:
+No javascript code will be execute until the css file is loaded. If the timeout is reached or loading the file will fail, StealJS terminates execution. 
+The benefit of this behavior, you don't get unstyled content in __production mode__. For example, if you are using [steal-tools.guides.progressive_loading]
+
+@body


### PR DESCRIPTION
adds docs for the new `cssOptions` 
https://github.com/stealjs/steal-css/pull/15

related to https://github.com/stealjs/steal/issues/261