### PR TITLE
Allow cookies to be sent over CORS requests

### DIFF
--- a/steal.js
+++ b/steal.js
@@ -2639,6 +2639,7 @@ function logloads(loads) {
         }
       };
       xhr.open("GET", url, true);
+      xhr.withCredentials = true;
 
       if (doTimeout)
         setTimeout(function() {


### PR DESCRIPTION
I'm using steal to fetch libraries from another site. Some of them require authentication with cookies. This small change will enable that. (By default CORS requests will have cookies and auth headers stripped out by the browser.)