### PR TITLE
npm plugin no longer crawls the first-level deps

### DIFF
--- a/ext/npm-convert.js
+++ b/ext/npm-convert.js
@@ -34,7 +34,7 @@ exports.forPackage = convertForPackage;
 
 // Translate helpers ===============
 // Given all the package.json data, these helpers help convert it to a source.
-function convertSteal(context, pkg, steal, root, ignoreWaiting) {
+function convertSteal(context, pkg, steal, root, ignoreWaiting, resavePackageInfo) {
 	if(!steal) {
 		return steal;
 	}
@@ -67,7 +67,7 @@ function convertSteal(context, pkg, steal, root, ignoreWaiting) {
 
 			// If we are building we need to resave the package's system
 			// configuration so that it will be written out into the build.
-			if(context.resavePackageInfo) {
+			if(context.resavePackageInfo && resavePackageInfo !== false) {
 				var info = utils.pkg.findPackageInfo(context, pkg);
 				info.steal = info.system = config;
 			}

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -372,7 +372,7 @@ exports.addExtension = function(System){
 		if(loader.npmContext) {
 			var context = loader.npmContext;
 			var pkg = context.versions.__default;
-			context.convert.steal(context, pkg, cfg, true);
+			context.convert.steal(context, pkg, cfg, true, false, false);
 			oldConfig.apply(loader, arguments);
 			return;
 		}

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -111,7 +111,8 @@ exports.addExtension = function(System){
 		var crawl = context && context.crawl;
 		var isDev = !!crawl;
 		if(!depPkg) {
-			if(crawl && !isRoot) {
+			// Development mode
+			if(crawl) {
 				var parentPkg = nameIsRelative ? null :
 					crawl.matchedVersion(context, refPkg.name,
 										 refPkg.version);

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -366,6 +366,17 @@ exports.addExtension = function(System){
 	var oldConfig = System.config;
 	System.config = function(cfg){
 		var loader = this;
+
+		// Use npm-convert if it is available as it is better
+		// and has the ability to push mappings into a waiting queue.
+		if(loader.npmContext) {
+			var context = loader.npmContext;
+			var pkg = context.versions.__default;
+			context.convert.steal(context, pkg, cfg, true);
+			oldConfig.apply(loader, arguments);
+			return;
+		}
+
 		for(var name in cfg) {
 			if(configSpecial[name]) {
 				cfg[name] = configSpecial[name].call(loader, cfg[name]);

--- a/ext/npm-utils.js
+++ b/ext/npm-utils.js
@@ -10,6 +10,7 @@
 var slice = Array.prototype.slice;
 var npmModuleRegEx = /.+@.+\..+\..+#.+/;
 var conditionalModuleRegEx = /#\{[^\}]+\}|#\?.+$/;
+var gitUrlEx = /(git|http(s?)):\/\//;
 
 var utils = {
 	extend: function(d, s, deep){
@@ -62,6 +63,9 @@ var utils = {
 	},
 	isEnv: function(name) {
 		return this.isEnv ? this.isEnv(name) : this.env === name;
+	},
+	isGitUrl: function(str) {
+		return gitUrlEx.test(str);
 	},
 	warnOnce: function(msg){
 		var w = this._warnings = this._warnings || {};

--- a/ext/npm.js
+++ b/ext/npm.js
@@ -38,6 +38,7 @@ exports.translate = function(load){
 		deferredConversions: {},
 		npmLoad: npmLoad,
 		crawl: crawl,
+		convert: convert,
 		resavePackageInfo: resavePackageInfo,
 		forwardSlashMap: {},
 		// default file structure for npm 3 and higher
@@ -47,7 +48,7 @@ exports.translate = function(load){
 	var pkg = {origFileUrl: load.address, fileUrl: utils.relativeURI(loader.baseURL, load.address)};
 	crawl.processPkgSource(context, pkg, load.source);
 	var pkgVersion = context.versions[pkg.name] = {};
-	pkgVersion[pkg.version] = pkg;
+	pkgVersion[pkg.version] = context.versions.__default = pkg;
 
 	// backwards compatible for < npm 3
 	var steal = utils.pkg.config(pkg);

--- a/ext/npm.js
+++ b/ext/npm.js
@@ -27,6 +27,7 @@ exports.translate = function(load){
 	var prevPackages = loader.npmContext && loader.npmContext.pkgInfo;
 	var context = {
 		packages: [],
+		pkgInfo: [],
 		loader: this,
 		// places we load package.jsons from
 		paths: {},
@@ -45,6 +46,8 @@ exports.translate = function(load){
 	this.npmContext = context;
 	var pkg = {origFileUrl: load.address, fileUrl: utils.relativeURI(loader.baseURL, load.address)};
 	crawl.processPkgSource(context, pkg, load.source);
+	var pkgVersion = context.versions[pkg.name] = {};
+	pkgVersion[pkg.version] = pkg;
 
 	// backwards compatible for < npm 3
 	var steal = utils.pkg.config(pkg);
@@ -55,10 +58,10 @@ exports.translate = function(load){
 		steal.npmAlgorithm = "flat";
 	}
 
-	return crawl.deps(context, pkg, true).then(function(){
+	return crawl.root(context, pkg, true).then(function(){
 		// clean up packages so everything is unique
 		var names = {};
-		var packages = context.pkgInfo = [];
+		var packages = context.pkgInfo;
 		utils.forEach(context.packages, function(pkg, index){
 			if(!packages[pkg.name+"@"+pkg.version]) {
 				if(pkg.browser){

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "qunitjs": "~1.12.0",
     "steal-env": "^1.0.0",
     "steal-es6-module-loader": "0.17.10",
-    "steal-npm": "1.0.0-alpha.5",
+    "steal-npm": "1.0.0-beta.0",
     "steal-qunit": "^0.1.4",
     "system-bower": "stealjs/system-bower#v0.2.1",
     "system-live-reload": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "qunitjs": "~1.12.0",
     "steal-env": "^1.0.0",
     "steal-es6-module-loader": "0.17.10",
-    "steal-npm": "1.0.0-beta.0",
+    "steal-npm": "1.0.0-beta.1",
     "steal-qunit": "^0.1.4",
     "system-bower": "stealjs/system-bower#v0.2.1",
     "system-live-reload": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "qunitjs": "~1.12.0",
     "steal-env": "^1.0.0",
     "steal-es6-module-loader": "0.17.10",
-    "steal-npm": "1.0.0-beta.1",
+    "steal-npm": "1.0.0-beta.2",
     "steal-qunit": "^0.1.4",
     "system-bower": "stealjs/system-bower#v0.2.1",
     "system-live-reload": "1.5.3",

--- a/steal.production.js
+++ b/steal.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v1.0.0-rc.11
+ *  steal v1.0.0-rc.12
  *  
  *  Copyright (c) 2016 Bitovi; Licensed MIT
  */

--- a/test/ext/npm.js
+++ b/test/ext/npm.js
@@ -38,6 +38,7 @@ exports.translate = function(load){
 		deferredConversions: {},
 		npmLoad: npmLoad,
 		crawl: crawl,
+		convert: convert,
 		resavePackageInfo: resavePackageInfo,
 		forwardSlashMap: {},
 		// default file structure for npm 3 and higher
@@ -47,7 +48,7 @@ exports.translate = function(load){
 	var pkg = {origFileUrl: load.address, fileUrl: utils.relativeURI(loader.baseURL, load.address)};
 	crawl.processPkgSource(context, pkg, load.source);
 	var pkgVersion = context.versions[pkg.name] = {};
-	pkgVersion[pkg.version] = pkg;
+	pkgVersion[pkg.version] = context.versions.__default = pkg;
 
 	// backwards compatible for < npm 3
 	var steal = utils.pkg.config(pkg);

--- a/test/ext/npm.js
+++ b/test/ext/npm.js
@@ -27,6 +27,7 @@ exports.translate = function(load){
 	var prevPackages = loader.npmContext && loader.npmContext.pkgInfo;
 	var context = {
 		packages: [],
+		pkgInfo: [],
 		loader: this,
 		// places we load package.jsons from
 		paths: {},
@@ -45,6 +46,8 @@ exports.translate = function(load){
 	this.npmContext = context;
 	var pkg = {origFileUrl: load.address, fileUrl: utils.relativeURI(loader.baseURL, load.address)};
 	crawl.processPkgSource(context, pkg, load.source);
+	var pkgVersion = context.versions[pkg.name] = {};
+	pkgVersion[pkg.version] = pkg;
 
 	// backwards compatible for < npm 3
 	var steal = utils.pkg.config(pkg);
@@ -55,10 +58,10 @@ exports.translate = function(load){
 		steal.npmAlgorithm = "flat";
 	}
 
-	return crawl.deps(context, pkg, true).then(function(){
+	return crawl.root(context, pkg, true).then(function(){
 		// clean up packages so everything is unique
 		var names = {};
-		var packages = context.pkgInfo = [];
+		var packages = context.pkgInfo;
 		utils.forEach(context.packages, function(pkg, index){
 			if(!packages[pkg.name+"@"+pkg.version]) {
 				if(pkg.browser){


### PR DESCRIPTION
This change makes it so that, when using the npm plugin, your first
level dependencies are no longer crawled. This means any plugins that
you use will need to be explicitly added in the steal.plugins
configuration:

```json
"dependencies": {
  "steal-less": "1.0.0"
},
"steal": {
  "plugins": ["steal-less"]
}
```

Using this config, steal will know to fetch steal-less' package.json,
      which will cause the configuration to be applied.