### PR TITLE
Adding OSX testing for Chrome/FF

### DIFF
--- a/test/test-sauce-labs.js
+++ b/test/test-sauce-labs.js
@@ -24,10 +24,17 @@ var account = new SauceLabs({
 var platforms = [{
 	browserName: 'firefox',
 	platform: 'Windows 10',
-	version: '49.0'
+	version: '50.0'
+}, {
+	browserName: 'firefox',
+	platform: 'OS X 10.11',
+	version: '50.0'
 }, {
 	browserName: 'googlechrome',
 	platform: 'Windows 10'
+}, {
+	browserName: 'googlechrome',
+	platform: 'OS X 10.11'
 }, {
 	browserName: 'safari',
 	platform: 'OS X 10.11',


### PR DESCRIPTION
This adds Chrome and Firefox to be tested with OSX, in addition to the
already-tested Windows.