### PR TITLE
Fix progressively loaded plugins configuration

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -93,7 +93,7 @@ var crawl = {
 				}
 			}
 
-			return crawl.loadPlugins(context, childPkg, isRoot, null,
+			return crawl.loadPlugins(context, childPkg, false, null,
 									skipSettingConfig).then(function(){
 				return localPkg;
 			});

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "saucelabs": "^1.3.0",
     "steal-env": "^1.0.0",
     "steal-es6-module-loader": "0.17.13",
-    "steal-npm": "1.0.0",
+    "steal-npm": "1.0.1",
     "steal-qunit": "^1.0.0",
     "system-bower": "stealjs/system-bower#v0.2.1",
     "system-live-reload": "1.5.3",


### PR DESCRIPTION
This fixes https://github.com/stealjs/steal/issues/957

When we progressively load a package we also load in `plugins`
configuration it has. This configuration should be treated not as from
the root package, because doing so has been causing it to be looked up
from too deep of a folder. This closes #957