### PR TITLE
Upgrade to steal-npm 1.0.3.

### DIFF
--- a/ext/npm-utils.js
+++ b/ext/npm-utils.js
@@ -11,10 +11,36 @@ var slice = Array.prototype.slice;
 var npmModuleRegEx = /.+@.+\..+\..+#.+/;
 var conditionalModuleRegEx = /#\{[^\}]+\}|#\?.+$/;
 var gitUrlEx = /(git|http(s?)):\/\//;
+var supportsSet = typeof Set === "function";
 
 var utils = {
-	extend: function(d, s, deep){
+	extend: function(d, s, deep, set){
 		var val;
+
+		if(deep) {
+			if(!set) {
+				if(supportsSet) {
+					set = new Set();
+				} else {
+					set = [];
+				}
+			}
+
+			if(supportsSet) {
+				if(set.has(s)) {
+					return s;
+				} else {
+					set.add(s);
+				}
+			} else {
+				if(set.indexOf(s) !== -1) {
+					return s;
+				} else {
+					set.push(s);
+				}
+			}
+		}
+
 		for(var prop in s) {
 			val = s[prop];
 
@@ -22,7 +48,7 @@ var utils = {
 				if(utils.isArray(val)) {
 					d[prop] = slice.call(val);
 				} else if(utils.isObject(val)) {
-					d[prop] = utils.extend({}, val, deep);
+					d[prop] = utils.extend({}, val, deep, set);
 				} else {
 					d[prop] = s[prop];
 				}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "saucelabs": "^1.3.0",
     "steal-env": "^1.0.0",
     "steal-es6-module-loader": "0.17.13",
-    "steal-npm": "1.0.2",
+    "steal-npm": "1.0.3",
     "steal-qunit": "^1.0.0",
     "system-bower": "stealjs/system-bower#v0.2.1",
     "system-live-reload": "1.5.3",


### PR DESCRIPTION
steal-npm 1.0.3 includes a fix for setting configuration on recursive
objects. This manifests when using the `instantiated` configuration and
the value is some type of object that points back to itself.