### PR TITLE
Upgrade to steal-npm 1.0.4

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -58,7 +58,7 @@ var crawl = {
 		});
 	},
 
-	dep: function(context, pkg, childPkg, isRoot, skipSettingConfig) {
+	dep: function(context, pkg, refPkg, childPkg, isRoot, skipSettingConfig) {
 		var versionAndRange = childPkg.name + "@" + childPkg.version;
 		if(context.fetchCache[versionAndRange]) {
 			return context.fetchCache[versionAndRange];
@@ -98,6 +98,13 @@ var crawl = {
 				});
 			}).then(function(localPkg){
 				if(!skipSettingConfig) {
+					// When progressively fetching package.jsons, we need to save
+					// the 'resolutions' so in production we get the *correct*
+					// version of a dependency.
+					if(refPkg) {
+						utils.pkg.saveResolution(context, refPkg, localPkg);
+					}
+
 					// Save package.json!npm load
 					npmModuleLoad.saveLoadIfNeeded(context);
 
@@ -166,7 +173,7 @@ var crawl = {
 		}, truthy);
 
 		return Promise.all(utils.map(needFetching, function(pluginPkg){
-			return crawl.dep(context, pkg, pluginPkg, isRoot, skipSettingConfig);
+			return crawl.dep(context, pkg, false, pluginPkg, isRoot, skipSettingConfig);
 		}));
 	},
 	/**

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -198,7 +198,7 @@ exports.addExtension = function(System){
 				return oldNormalize.call(this, name, parentName, parentAddress,
 										 pluginNormalize);
 			}
-			return crawl.dep(this.npmContext, parentPkg, depPkg, isRoot)
+			return crawl.dep(this.npmContext, parentPkg, refPkg, depPkg, isRoot)
 				.then(createModuleNameAndNormalize);
 		} else {
 			return createModuleNameAndNormalize(depPkg);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "saucelabs": "^1.3.0",
     "steal-env": "^1.0.0",
     "steal-es6-module-loader": "0.17.14",
-    "steal-npm": "1.0.3",
+    "steal-npm": "1.0.4",
     "steal-qunit": "^1.0.0",
     "system-bower": "stealjs/system-bower#v0.2.1",
     "system-live-reload": "1.5.3",


### PR DESCRIPTION
steal 1.0.4 includes a fix for a bug when 2 versions of a package exists
in production.