### PR TITLE
Simplify using steal-clone with default exports

### DIFF
--- a/docs/module-steal-clone.md
+++ b/docs/module-steal-clone.md
@@ -42,7 +42,9 @@ clone({
       return 'moduleBOverride';
     }
   }
-}).import('moduleA', function(moduleA) {
+})
+.import('moduleA')
+.then(function(moduleA) {
   moduleA(); // moduleA moduleBOverride
 });
 ```

--- a/ext/steal-clone.js
+++ b/ext/steal-clone.js
@@ -4,10 +4,15 @@ function setModule(moduleName, parentName, moduleOverrides) {
 	return new Promise(function(resolve) {
 		newLoader.normalize(moduleName, parentName)
 		.then(function(normalizedModuleName) {
+			var moduleObject = moduleOverrides[moduleName];
+
+			// if overriding default export, make sure __useDefault is set
+			if (moduleObject.hasOwnProperty('default') && !moduleObject.hasOwnProperty('__useDefault')) {
+				moduleObject.__useDefault = true;
+			}
+
 			// set module overrides
-			newLoader.set(normalizedModuleName, newLoader.newModule(
-				moduleOverrides[moduleName]
-			));
+			newLoader.set(normalizedModuleName, newLoader.newModule(moduleObject));
 			resolve();
 		});
 	});

--- a/test/ext-steal-clone/default-export-usedefault/index.html
+++ b/test/ext-steal-clone/default-export-usedefault/index.html
@@ -1,0 +1,10 @@
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+	<script type="text/javascript"
+		src='../../../steal.js'
+		data-config="../../config.js"
+		data-main="ext-steal-clone/default-export-usedefault/main"></script>
+</body>

--- a/test/ext-steal-clone/default-export-usedefault/main.js
+++ b/test/ext-steal-clone/default-export-usedefault/main.js
@@ -1,0 +1,35 @@
+var clone = require('steal-clone');
+
+var moduleObject = { abc: 'xyz' };
+
+clone({
+	'fooBarBaz': {
+		default: moduleObject,
+		__useDefault: true
+	}
+})
+.import('fooBarBaz')
+.then(function(fooBarBaz) {
+	if (typeof window !== "undefined" && window.QUnit) {
+		QUnit.ok(fooBarBaz === moduleObject, 'default export should be the passed object');
+
+		try {
+			fooBarBaz.def = 'uvw';
+			QUnit.equal(fooBarBaz.def, 'uvw', 'should be able to set a property on the default export object');
+		} catch(e) {
+			QUnit.ok(false, 'error setting a property on the default export object: ' + e);
+		}
+
+		QUnit.start();
+		removeMyself();
+	} else {
+		console.log('fooBarBaz === moduleObject:', fooBarBaz === moduleObject);
+
+		try {
+			fooBarBaz.def = 'uvw';
+			console.log("fooBarBaz.def === 'uvw':", fooBarBaz.def === 'uvw');
+		} catch(e) {
+			console.log('error setting a property on the default export object:', e);
+		}
+	}
+});

--- a/test/ext-steal-clone/default-export/index.html
+++ b/test/ext-steal-clone/default-export/index.html
@@ -1,0 +1,10 @@
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+	<script type="text/javascript"
+		src='../../../steal.js'
+		data-config="../../config.js"
+		data-main="ext-steal-clone/default-export/main"></script>
+</body>

--- a/test/ext-steal-clone/default-export/main.js
+++ b/test/ext-steal-clone/default-export/main.js
@@ -1,0 +1,34 @@
+var clone = require('steal-clone');
+
+var moduleObject = { abc: 'xyz' };
+
+clone({
+	'fooBarBaz': {
+		default: moduleObject
+	}
+})
+.import('fooBarBaz')
+.then(function(fooBarBaz) {
+	if (typeof window !== "undefined" && window.QUnit) {
+		QUnit.ok(fooBarBaz === moduleObject, 'default export should be the passed object');
+
+		try {
+			fooBarBaz.def = 'uvw';
+			QUnit.equal(fooBarBaz.def, 'uvw', 'should be able to set a property on the default export object');
+		} catch(e) {
+			QUnit.ok(false, 'error setting a property on the default export object: ' + e);
+		}
+
+		QUnit.start();
+		removeMyself();
+	} else {
+		console.log('fooBarBaz === moduleObject:', fooBarBaz === moduleObject);
+
+		try {
+			fooBarBaz.def = 'uvw';
+			console.log("fooBarBaz.def === 'uvw':", fooBarBaz.def === 'uvw');
+		} catch(e) {
+			console.log('error setting a property on the default export object:', e);
+		}
+	}
+});

--- a/test/test.js
+++ b/test/test.js
@@ -460,6 +460,14 @@ QUnit.config.testTimeout = 30000;
 		makeIframe("ext-steal-clone/config-separation/index.html");
 	});
 
+	asyncTest("allows you to override a module with a default export", function() {
+		makeIframe("ext-steal-clone/default-export-usedefault/index.html");
+	});
+
+	asyncTest("allows you to override a module with a default export without setting __useDefault", function() {
+		makeIframe("ext-steal-clone/default-export/index.html");
+	});
+
 	asyncTest("caches source of parent modules to avoid duplicate downloads", function() {
 		makeIframe("ext-steal-clone/fetch-cache/index.html");
 	});


### PR DESCRIPTION
Previously to override a default export with steal-clone, you had to do:
```
clone({
  'jquerty': {
    default: {},
    __useDefault: true
  }
})
```

With this change, you do not need to pass `__useDefault` and steal-clone will set it for you.

Closes https://github.com/stealjs/steal/issues/985.