### PR TITLE
refactor steal-trace tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-simple-mocha": "^0.4.0",
     "http-server": "^0.9.0",
     "jquery": "^3.1.1",
-    "qunitjs": "1.12.0",
+    "qunitjs": "^1.17.1",
     "saucelabs": "^1.3.0",
     "steal-env": "^1.0.0",
     "steal-es6-module-loader": "0.17.14",
@@ -119,8 +119,7 @@
       "string_decoder",
       "tty-browserify",
       "process",
-      "punycode",
-      "steal-qunit"
+      "punycode"
     ]
   },
   "repository": {

--- a/src/trace/trace_test.html
+++ b/src/trace/trace_test.html
@@ -3,11 +3,23 @@
 <head>
 	<meta charset="UTF-8">
 	<title>trace extension tests</title>
-	<link rel="stylesheet" type="text/css" href="../../node_modules/qunitjs/qunit/qunit.css"/>
 </head>
 <body>
 	<div id="qunit"></div>
 	<div id="qunit-fixture"></div>
+	<script>
+		var steal = {
+			paths: {
+				"steal-qunit": "node_modules/steal-qunit/steal-qunit.js"
+			},
+			map: {
+				"qunitjs": "node_modules/qunitjs"
+			},
+			ext : {
+				css : "node_modules/steal-css/css.js"
+			}
+		}
+	</script>
 	<script
 		src="../../steal.js"
 		main="src/trace/trace_test"


### PR DESCRIPTION
remove `steal-qunit` from steal's `steal.npmDependencies` because that cause loading `steal-qunit` all the time.
make the tests working again by adding some paths and mapping.

this PR is blocked by https://github.com/stealjs/steal-qunit/issues/22
the `trace-test.html` will never start