### PR TITLE
Use resolutions to determine which pkg version to use.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test/bower/as_config/vendor/steal/
 !test/nested-npm-algorithm/node_modules/some/node_modules/
 !test/import-js-file/node_modules/
 src/loader/loader-esnext.js
+test/npm/bower/node_modules/steal/
 
 !test/npm/*/node_modules
 test/npm/live-reload/node_modules/

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -120,9 +120,12 @@ exports.addExtension = function(System){
 				if(parentPkg) {
 					wantedPkg = crawl.getDependencyMap(this, parentPkg, isRoot)[parsedModuleName.packageName];
 					if(wantedPkg) {
+						var wantedVersion = (refPkg.resolutions &&
+							refPkg.resolutions[wantedPkg.name]) || wantedPkg.version;
+
 						var foundPkg = crawl.matchedVersion(this.npmContext,
 															wantedPkg.name,
-															wantedPkg.version);
+															wantedVersion);
 						if(foundPkg) {
 							depPkg = utils.pkg.findByUrl(this, foundPkg.fileUrl);
 						}


### PR DESCRIPTION
This bug depends on precise loading timing that I was unable to recreate
in a test. What needs to happen is module A and B need to load the dep
at the exact same time, with module B getting an incorrect version the
first time, and module A using that incorrect version in its normalize
resolution.

This fixes #1075

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
