### PR TITLE
Include devDependencies when resolving child package's deps

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -248,12 +248,11 @@ var crawl = {
 		addDeps(packageJSON, packageJSON.peerDependencies || {}, deps,
 				"peerDependencies", {_isPeerDependency: true});
 
-		addDeps(packageJSON, packageJSON.dependencies || {}, deps, "dependencies");
+		addDeps(packageJSON, packageJSON.dependencies || {}, deps,
+			"dependencies");
 
-		if(isRoot) {
-			addDeps(packageJSON, packageJSON.devDependencies || {}, deps,
-				   "devDependencies");
-		}
+		addDeps(packageJSON, packageJSON.devDependencies || {}, deps,
+			"devDependencies");
 
 		return deps;
 	},

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -851,6 +851,47 @@ QUnit.test("A package's steal.main is retained when loading dependant packages",
 	.then(done, helpers.fail(assert, done));
 });
 
+QUnit.test("A dependency can load its devDependencies if they happen to exist", function(assert){
+	var done = assert.async();
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				foo: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "foo",
+				main: "main.js",
+				version: "1.0.0",
+				dependencies: {
+					bar: "1.0.0"
+				}
+			},
+			{
+				name: "bar",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("foo", "app@1.0.0#main");
+	})
+	.then(function(){
+		return loader.normalize("bar", "foo@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "bar@1.0.0#main");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 QUnit.module("plugins configuration");
 
 QUnit.test("Works from the root package", function(assert){


### PR DESCRIPTION
When resolving a change package, include its devDependencies in the
equation. This way, if a child package tries to load a devDependency
we'll at least try to load it (it may be installed by a different
    module).

Fixes #1079

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
