### PR TITLE
Tighten restriction on use of devDependencies

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -201,10 +201,11 @@ var crawl = {
 	 * @param {Object} loader
 	 * @param {NpmPackage} packageJSON
 	 * @param {Boolean} [isRoot]
+	 * @param {Boolean} [includeDev]
 	 * @return {Array<String>}
 	 */
 	getDependencies: function(loader, packageJSON, isRoot){
-		var deps = crawl.getDependencyMap(loader, packageJSON, isRoot);
+		var deps = crawl.getDependencyMap(loader, packageJSON, isRoot, includeDev);
 
 		var dependencies = [];
 		for(var name in deps) {
@@ -218,9 +219,10 @@ var crawl = {
 	 * @param {Object} loader
 	 * @param {Object} packageJSON
 	 * @param {Boolean} isRoot
+	 * @param {Boolean} includeDevDependenciesIfNotRoot
 	 * @return {Object<String,Range>} A map of dependency names and requested version ranges.
 	 */
-	getDependencyMap: function(loader, packageJSON, isRoot){
+	getDependencyMap: function(loader, packageJSON, isRoot, includeDevDependenciesIfNotRoot){
 		var config = utils.pkg.config(packageJSON);
 		var hasConfig = !!config;
 
@@ -251,8 +253,10 @@ var crawl = {
 		addDeps(packageJSON, packageJSON.dependencies || {}, deps,
 			"dependencies");
 
-		addDeps(packageJSON, packageJSON.devDependencies || {}, deps,
-			"devDependencies");
+		if(isRoot || includeDevDependenciesIfNotRoot) {
+			addDeps(packageJSON, packageJSON.devDependencies || {}, deps,
+				"devDependencies");
+		}
 
 		return deps;
 	},

--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -222,7 +222,7 @@ var crawl = {
 	 * @param {Boolean} includeDevDependenciesIfNotRoot
 	 * @return {Object<String,Range>} A map of dependency names and requested version ranges.
 	 */
-	getDependencyMap: function(loader, packageJSON, isRoot, includeDevDependenciesIfNotRoot){
+	getDependencyMap: function(loader, packageJSON, isRoot){
 		var config = utils.pkg.config(packageJSON);
 		var hasConfig = !!config;
 
@@ -253,11 +253,21 @@ var crawl = {
 		addDeps(packageJSON, packageJSON.dependencies || {}, deps,
 			"dependencies");
 
-		if(isRoot || includeDevDependenciesIfNotRoot) {
+		if(isRoot) {
 			addDeps(packageJSON, packageJSON.devDependencies || {}, deps,
 				"devDependencies");
 		}
 
+		return deps;
+	},
+	/**
+	 * Return a map of all dependencies from a package.json, including
+	 * devDependencies
+	 */
+	getFullDependencyMap: function(loader, packageJSON, isRoot){
+		var deps = crawl.getDependencyMap(loader, packageJSON, isRoot);
+		addDeps(packageJSON, packageJSON.devDependencies || {}, deps,
+			"devDependencies");
 		return deps;
 	},
 	getPlugins: function(packageJSON, deps) {

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -118,7 +118,7 @@ exports.addExtension = function(System){
 					crawl.matchedVersion(context, refPkg.name,
 										 refPkg.version);
 				if(parentPkg) {
-					wantedPkg = crawl.getDependencyMap(this, parentPkg, isRoot)[parsedModuleName.packageName];
+					wantedPkg = crawl.getDependencyMap(this, parentPkg, isRoot, true)[parsedModuleName.packageName];
 					if(wantedPkg) {
 						var wantedVersion = (refPkg.resolutions &&
 							refPkg.resolutions[wantedPkg.name]) || wantedPkg.version;
@@ -190,7 +190,7 @@ exports.addExtension = function(System){
 				var parentPkg = crawl.matchedVersion(this.npmContext, refPkg.name,
 													 refPkg.version);
 				if(parentPkg) {
-					depPkg = crawl.getDependencyMap(this, parentPkg, isRoot)[parsedModuleName.packageName];
+					depPkg = crawl.getDependencyMap(this, parentPkg, isRoot, true)[parsedModuleName.packageName];
 				}
 			}
 

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -118,7 +118,8 @@ exports.addExtension = function(System){
 					crawl.matchedVersion(context, refPkg.name,
 										 refPkg.version);
 				if(parentPkg) {
-					wantedPkg = crawl.getDependencyMap(this, parentPkg, isRoot, true)[parsedModuleName.packageName];
+					var depMap = crawl.getFullDependencyMap(this, parentPkg, isRoot);
+					wantedPkg = depMap[parsedModuleName.packageName];
 					if(wantedPkg) {
 						var wantedVersion = (refPkg.resolutions &&
 							refPkg.resolutions[wantedPkg.name]) || wantedPkg.version;
@@ -190,7 +191,8 @@ exports.addExtension = function(System){
 				var parentPkg = crawl.matchedVersion(this.npmContext, refPkg.name,
 													 refPkg.version);
 				if(parentPkg) {
-					depPkg = crawl.getDependencyMap(this, parentPkg, isRoot, true)[parsedModuleName.packageName];
+					var depMap = crawl.getFullDependencyMap(this, parentPkg, isRoot);
+					depPkg = depMap[parsedModuleName.packageName];
 				}
 			}
 

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -867,7 +867,7 @@ QUnit.test("A dependency can load its devDependencies if they happen to exist", 
 				name: "foo",
 				main: "main.js",
 				version: "1.0.0",
-				dependencies: {
+				devDependencies: {
 					bar: "1.0.0"
 				}
 			},
@@ -888,6 +888,48 @@ QUnit.test("A dependency can load its devDependencies if they happen to exist", 
 	})
 	.then(function(name){
 		assert.equal(name, "bar@1.0.0#main");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("A dependency's devDependencies are not fetched when in 'plugins'", function(assert){
+	var done = assert.async();
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				foo: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "foo",
+				main: "main.js",
+				version: "1.0.0",
+				devDependencies: {
+					bar: "1.0.0"
+				},
+				steal: {
+					plugins: ["bar"]
+				}
+			},
+			{
+				name: "bar",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("foo", "app@1.0.0#main");
+	})
+	.then(function(name){
+		var pkg = loader.npmPaths["./node_modules/bar"];
+		assert.equal(pkg, undefined, "This should not be fetched");
 	})
 	.then(done, helpers.fail(assert, done));
 });


### PR DESCRIPTION
This tightens when we consider a devDependency to be part of the
dependencyMap. This map is used for a few things in the npm plugin. We
only want to include devDependency in this map when trying to normalize
a name. This changes the method so that it accepts a boolean that
decides where devDependencies should be included or not, so that it is
restricted to just that use case.

Fixes #1086

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
