### PR TITLE
Progressive loading: use jquery's full path to node_modules folder

### DIFF
--- a/docs/pages/progressive-loading.md
+++ b/docs/pages/progressive-loading.md
@@ -55,14 +55,14 @@ Create _myhub.html_ with:
 Next install and run a local fileserver. [http-server](https://www.npmjs.com/package/http-server) handles our basic needs. We'll install it locally and then and it to our npm scripts:
 
 ```
-> npm install http-server --save
+> npm install http-server --save-dev
 ```
 
 Next edit your `package.json` so that the start script looks like:
 
 ```json
 "scripts": {
-  "start": "http-server"
+  "start": "http-server -c-1 ."
 }
 ```
 
@@ -81,7 +81,7 @@ Open [http://127.0.0.1:8080/myhub.html](http://127.0.0.1:8080/myhub.html). You s
 Installing these 3 dependencies gives us everything we need to build our application.
 
 ```
-> npm install steal jquery --save
+> npm install steal jquery --save-dev
 > npm install steal-tools steal-less steal-css --save-dev
 ```
 
@@ -187,7 +187,7 @@ Internally Steal resolves all module identifiers into [moduleName moduleNames], 
 Next install bootstrap with:
 
 ```
-> npm install bootstrap --save
+> npm install bootstrap --save-dev
 ```
 
 Update the _myhub.html_ to use bootstrap with:
@@ -247,7 +247,7 @@ Create _repos/repos.html_ with:
 	  <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <div id="repos"/>
+    <div id="repos"></div>
     <script src="../node_modules/steal/steal.js" main="@empty"></script>
 	<script type="text/steal-module">
         import repos from "myhub/repos/repos";
@@ -319,22 +319,22 @@ import repos from "./repos";
 
 QUnit.module("myhub/repos/");
 
-QUnit.test("basics", function(){
-    QUnit.stop();
+QUnit.test("basics", function(assert){
+	var done = assert.async();
     var fixtureEl = document.getElementById("qunit-fixture");
 
     repos(fixtureEl);
 
-    QUnit.equal(
+    assert.equal(
         fixtureEl.innerHTML,
         "Loading...", "starts with loading");
 
     var interval = setInterval(function(){
         var dl = fixtureEl.getElementsByTagName("dl");
         if(dl.length === 1) {
-            QUnit.ok(true, "inserted a dl");
-            QUnit.start();
+            assert.ok(true, "inserted a dl");
             clearInterval(interval);
+			done();
         }
     },100);
 });
@@ -378,27 +378,29 @@ import $ from "jquery";
 
 QUnit.module("myhub/repos/");
 
-QUnit.test("basics", function(){
-    QUnit.stop();
+QUnit.test("basics", function(assert){
+	var done = assert.async();
     var fixtureEl = document.getElementById("qunit-fixture");
 
     repos(fixtureEl);
 
-    QUnit.equal(
+    assert.equal(
         fixtureEl.innerHTML,
         "Loading...", "starts with loading");
 
     var interval = setInterval(function(){
         var dl = fixtureEl.getElementsByTagName("dl");
         if(dl.length === 1) {
-            QUnit.ok(true, "inserted a dl");
-            QUnit.start();
+            assert.ok(true, "inserted a dl");
             clearInterval(interval);
+			done();
         }
     },100);
 });
 
-QUnit.asyncTest("basics with dependency injection", function(){
+QUnit.test("basics with dependency injection", function(assert){
+	var done = assert.async();
+
     var jQuery = function(selector){
         return $(selector)
     };
@@ -414,9 +416,9 @@ QUnit.asyncTest("basics with dependency injection", function(){
 
             var html = $("#qunit-fixture").html();
 
-            QUnit.ok(/href="http:\/\/stealjs.com"/.test(html),
+            assert.ok(/href="http:\/\/stealjs.com"/.test(html),
               "updated with request");
-            QUnit.start();
+			done();
         },1);
     };
 
@@ -447,7 +449,7 @@ First we'll install a library for displaying a gallery of images. This library i
 
 Run:
 ```
-> npm install justifiedGallery --save
+> npm install justifiedGallery --save-dev
 ```
 
 ### Create the modlet

--- a/docs/pages/progressive-loading.md
+++ b/docs/pages/progressive-loading.md
@@ -510,14 +510,17 @@ Change _package.json_ to:
      "meta": {
          "justifiedGallery/src/js/justifiedGallery": {
              "format": "global",
-             "deps": ["jquery","justifiedGallery/src/less/justifiedGallery.less"]
+             "deps": [
+				"node_modules/jquery/dist/jquery.js",
+				"justifiedGallery/src/less/justifiedGallery.less"
+			 ]
          }
      }
   }
 }
 ```
 
-@highlight 9-17
+@highlight 9-20
 
 ### Use justifiedGallery
 


### PR DESCRIPTION
Ref: steal/issues/1104

Based on #1105, actual change https://github.com/stealjs/steal/pull/1106/commits/406e34ca9edb937172249ba47509333eebd33c0a