### PR TITLE
Allow loading packages that are not direct dependencies

### DIFF
--- a/ext/npm-convert.js
+++ b/ext/npm-convert.js
@@ -207,7 +207,6 @@ function convertName (context, pkg, map, root, name, waiting) {
 	}
 }
 
-
 /**
  * Converts browser names into actual module names.
  *

--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -429,7 +429,7 @@ var crawl = {
 	 * Find a package and its parents.
 	 * [package:{}, parent1, parent2, ...]
 	 * @param {Object} context
-	 * @parent {String} name the package name
+	 * @param {String} name the package name
 	 */
 	findPackageAndParents: function(context, name) {
 		return context.packageParents[name];

--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -27,6 +27,7 @@ var crawl = {
 	 */
 	root: function(context, pkg){
 		var deps = crawl.getDependencyMap(context.loader, pkg, true);
+		crawl.setParent(context, pkg, true);
 
 		var pluginsPromise = crawl.loadPlugins(context, pkg, true, deps, true);
 		var stealPromise = crawl.loadSteal(context, pkg, true, deps);
@@ -58,7 +59,6 @@ var crawl = {
 			});
 		});
 	},
-
 	dep: function(context, pkg, refPkg, childPkg, isRoot, skipSettingConfig) {
 		var versionAndRange = childPkg.name + "@" + childPkg.version;
 		if(context.fetchCache[versionAndRange]) {
@@ -162,6 +162,7 @@ var crawl = {
 		return npmLoad(context, childPkg, requestedVersion)
 		.then(function(pkg){
 			crawl.setVersionsConfig(context, pkg, requestedVersion);
+			crawl.setParent(context, pkg, isRoot);
 			return pkg;
 		});
 	},
@@ -201,11 +202,10 @@ var crawl = {
 	 * @param {Object} loader
 	 * @param {NpmPackage} packageJSON
 	 * @param {Boolean} [isRoot]
-	 * @param {Boolean} [includeDev]
 	 * @return {Array<String>}
 	 */
 	getDependencies: function(loader, packageJSON, isRoot){
-		var deps = crawl.getDependencyMap(loader, packageJSON, isRoot, includeDev);
+		var deps = crawl.getDependencyMap(loader, packageJSON, isRoot);
 
 		var dependencies = [];
 		for(var name in deps) {
@@ -407,6 +407,32 @@ var crawl = {
 		}
 		var versions = context.versions[pkg.name];
 		versions[versionRange] = pkg;
+	},
+	/**
+	 * Set this package's dependencies, marking itself as a parent.
+	 * { childPkg: [parent1, parent2] }
+	 */
+	setParent: function(context, pkg, isRoot) {
+		var deps = crawl.getDependencies(context.loader, pkg, isRoot);
+		deps.forEach(function(childDep){
+			var name = childDep.name;
+			var parents = context.packageParents[name]
+			if(!parents) {
+				parents = context.packageParents[name] = [];
+				parents.package = childDep;
+			}
+			parents.push(pkg);
+		});
+	},
+	/**
+	 * @function findPackageAndParents
+	 * Find a package and its parents.
+	 * [package:{}, parent1, parent2, ...]
+	 * @param {Object} context
+	 * @parent {String} name the package name
+	 */
+	findPackageAndParents: function(context, name) {
+		return context.packageParents[name];
 	},
 	pkgSatisfies: function(pkg, versionRange) {
 		return SemVer.validRange(versionRange) &&

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -184,15 +184,26 @@ exports.addExtension = function(System){
 									 parentName, parentAddress, pluginNormalize);
 		}
 
-		// TODO Here is where we should progressively load the package.json files.
+		// This is the beginning of progressively loading package.json
 		var loader = this;
 		if(!depPkg) {
 			if(crawl) {
 				var parentPkg = crawl.matchedVersion(this.npmContext, refPkg.name,
 													 refPkg.version);
+
 				if(parentPkg) {
 					var depMap = crawl.getFullDependencyMap(this, parentPkg, isRoot);
 					depPkg = depMap[parsedModuleName.packageName];
+
+					// If we still haven't found a package, try to find it by
+					// name, we'll take whatever we can get.
+					if(!depPkg) {
+						var parents = crawl.findPackageAndParents(this.npmContext,
+							parsedModuleName.packageName);
+						if(parents) {
+							depPkg = parents.package;
+						}
+					}
 				}
 			}
 

--- a/ext/npm.js
+++ b/ext/npm.js
@@ -34,6 +34,11 @@ exports.translate = function(load){
 		// paths that are currently be loaded
 		loadingPaths: {},
 		versions: {},
+		// A map of packages to its parents. This is used so that
+		// we can find a package by name and get its parent packages,
+		// in order to load bare module specifiers that refer to packages
+		// that are not listed as dependencies
+		packageParents: {},
 		fetchCache: {},
 		deferredConversions: {},
 		npmLoad: npmLoad,

--- a/test/npm/bower/node_modules/steal/ext/npm-convert.js
+++ b/test/npm/bower/node_modules/steal/ext/npm-convert.js
@@ -43,6 +43,14 @@ function convertSteal(context, pkg, steal, root, ignoreWaiting, resavePackageInf
 	if(steal.meta) {
 		steal.meta = convertPropertyNames(context, pkg, steal.meta, root,
 										  waiting);
+
+		convertMetaDeps({
+			context: context,
+			pkg: pkg,
+			meta: steal.meta,
+			root: root,
+			waiting: waiting
+		});
 	}
 	if(steal.map) {
 		steal.map = convertPropertyNamesAndValues(context, pkg, steal.map,
@@ -207,6 +215,31 @@ function convertName (context, pkg, map, root, name, waiting) {
 	}
 }
 
+/**
+ * Convert each module name defined in `meta.deps`
+ */
+function convertMetaDeps(opts) {
+	if (!opts.meta) {
+		return;
+	}
+
+	for (var key in opts.meta) {
+		var mod = opts.meta[key];
+
+		if (mod.deps) {
+			var converted = [];
+
+			mod.deps.forEach(function(dep) {
+				if (dep) {
+					converted.push(convertName(opts.context, opts.pkg, opts.meta,
+						opts.root, dep, opts.waiting));
+				}
+			});
+
+			mod.deps = converted;
+		}
+	}
+}
 
 /**
  * Converts browser names into actual module names.

--- a/test/npm/test.html
+++ b/test/npm/test.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="../../../node_modules/qunitjs/qunit/qunit.css"/>
 </head>
 <body>
-	<h1 id="qunit-header">system-npm Steal Test Suite</h1>
+	<h1 id="qunit-header">npm extension test suite</h1>
 
 	<h2 id="qunit-banner"></h2>
 	<div id="qunit-testrunner-toolbar"></div>


### PR DESCRIPTION
This change makes it possible so that you can load dependencies from
which you do not actual depend on.

Meaning if you have:

```js
require("jquery");
```

In your code, but your package does not directly depend on `jquery`,
   then it is possible you will load jquery from npm anyways; if jquery
   happens to exist within any parent package.

Closes #971

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
