### PR TITLE
Move steal-clone extension tests into file

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,9 @@
 	"describe": true,
 	"afterEach": true,
 	"it": true,
-	"customLoader": true
+	"customLoader": true,
+	"assert": true,
+	"done": true
   },
 
   "curly": true,

--- a/test/ext-steal-clone/basics/index.html
+++ b/test/ext-steal-clone/basics/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/basics/main"></script>
 </body>

--- a/test/ext-steal-clone/basics/main.js
+++ b/test/ext-steal-clone/basics/main.js
@@ -1,36 +1,39 @@
 var stealClone = require('steal-clone');
 var loader = require('@loader');
+
 loader.config({
-  foo: 'bar',
-  bar: function() {}
+	foo: 'bar',
+	bar: function() {}
 });
 
 var clone = stealClone({
-  'ext-steal-clone/basics/moduleB': {
-    getName: function() {
-      return 'mockModuleB';
-    }
-  }
+	'ext-steal-clone/basics/moduleB': {
+		getName: function() {
+			return 'mockModuleB';
+		}
+	}
 });
 
-if (typeof window !== "undefined" && window.QUnit) {
-	QUnit.equal(typeof clone.import, 'function', 'steal-clone should return an import function');
-	QUnit.equal(clone.foo, 'bar', 'clone should contain config properties that are not functions');
-	QUnit.ok(!clone.bar, 'clone should not contain config properties that are functions');
+if (window.assert) {
+	assert.equal(typeof clone.import, 'function', 'steal-clone should return an import function');
+	assert.equal(clone.foo, 'bar', 'clone should contain config properties that are not functions');
+	assert.ok(!clone.bar, 'clone should not contain config properties that are functions');
 } else {
-  console.log('clone.import:', clone.import);
-  console.log('clone.foo:', clone.foo);
-  console.log('clone.bar:', clone.bar);
+	console.log('clone.import:', clone.import);
+	console.log('clone.foo:', clone.foo);
+	console.log('clone.bar:', clone.bar);
 }
 
 clone.import('ext-steal-clone/basics/moduleA')
-  .then(function(moduleA) {
-    if (typeof window !== "undefined" && window.QUnit) {
-      QUnit.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
-
-    	QUnit.start();
-    	removeMyself();
-    } else {
-          console.log('moduleA.getName():', moduleA.getName());
-    }
-  });
+	.then(function(moduleA) {
+		if (window.assert) {
+			assert.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
+			done();
+		} else {
+			console.log('moduleA.getName():', moduleA.getName());
+		}
+	})
+	.then(null, function(err) {
+		assert.notOk(err, "should not fail");
+		done();
+	});

--- a/test/ext-steal-clone/config-separation/index.html
+++ b/test/ext-steal-clone/config-separation/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/config-separation/main"></script>
 </body>

--- a/test/ext-steal-clone/config-separation/main.js
+++ b/test/ext-steal-clone/config-separation/main.js
@@ -8,9 +8,9 @@ function excludeRegistry() {
 
   clone.delete(deletedModule);
 
-  if (typeof window !== "undefined" && window.QUnit) {
-    QUnit.ok(!clone.has(deletedModule), 'should delete module from clone');
-    QUnit.ok(steal.loader.has(deletedModule), 'should not delete module from loader');
+  if (typeof window !== "undefined" && window.assert) {
+    assert.ok(!clone.has(deletedModule), 'should delete module from clone');
+    assert.ok(steal.loader.has(deletedModule), 'should not delete module from loader');
   } else {
     console.log(' clone.has(' + deletedModule + '):', clone.has(deletedModule));
     console.log('steal.loader.has(' + deletedModule + '):', steal.loader.has(deletedModule));
@@ -23,9 +23,9 @@ function excludeExtensions() {
   function cloneExtension() {}
   clone._extensions.push(cloneExtension);
 
-  if (typeof window !== "undefined" && window.QUnit) {
-    QUnit.ok(clone._extensions.indexOf(cloneExtension) >= 0, 'clone should include new extensions');
-    QUnit.ok(steal.loader._extensions.indexOf(cloneExtension) < 0, 'steal.loader should not include new extensions');
+  if (typeof window !== "undefined" && window.assert) {
+    assert.ok(clone._extensions.indexOf(cloneExtension) >= 0, 'clone should include new extensions');
+    assert.ok(steal.loader._extensions.indexOf(cloneExtension) < 0, 'steal.loader should not include new extensions');
   } else {
     console.log('index of cloneExtension in clone:', clone._extensions.indexOf(cloneExtension));
     console.log('index of cloneExtension in steal.loader:', steal.loader._extensions.indexOf(cloneExtension));
@@ -37,8 +37,7 @@ function excludeExtensions() {
 excludeRegistry()
   .then(excludeExtensions)
   .then(function() {
-    if (typeof window !== "undefined" && window.QUnit) {
-      QUnit.start();
-      removeMyself();
+    if (typeof window !== "undefined" && window.assert) {
+      done();
     }
   });

--- a/test/ext-steal-clone/default-export-usedefault/index.html
+++ b/test/ext-steal-clone/default-export-usedefault/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/default-export-usedefault/main"></script>
 </body>

--- a/test/ext-steal-clone/default-export-usedefault/main.js
+++ b/test/ext-steal-clone/default-export-usedefault/main.js
@@ -10,18 +10,17 @@ clone({
 })
 .import('fooBarBaz')
 .then(function(fooBarBaz) {
-	if (typeof window !== "undefined" && window.QUnit) {
-		QUnit.ok(fooBarBaz === moduleObject, 'default export should be the passed object');
+	if (typeof window !== "undefined" && window.assert) {
+		assert.ok(fooBarBaz === moduleObject, 'default export should be the passed object');
 
 		try {
 			fooBarBaz.def = 'uvw';
-			QUnit.equal(fooBarBaz.def, 'uvw', 'should be able to set a property on the default export object');
+			assert.equal(fooBarBaz.def, 'uvw', 'should be able to set a property on the default export object');
 		} catch(e) {
-			QUnit.ok(false, 'error setting a property on the default export object: ' + e);
+			assert.ok(false, 'error setting a property on the default export object: ' + e);
 		}
 
-		QUnit.start();
-		removeMyself();
+		done();
 	} else {
 		console.log('fooBarBaz === moduleObject:', fooBarBaz === moduleObject);
 

--- a/test/ext-steal-clone/default-export/index.html
+++ b/test/ext-steal-clone/default-export/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/default-export/main"></script>
 </body>

--- a/test/ext-steal-clone/default-export/main.js
+++ b/test/ext-steal-clone/default-export/main.js
@@ -9,18 +9,17 @@ clone({
 })
 .import('fooBarBaz')
 .then(function(fooBarBaz) {
-	if (typeof window !== "undefined" && window.QUnit) {
-		QUnit.ok(fooBarBaz === moduleObject, 'default export should be the passed object');
+	if (typeof window !== "undefined" && window.assert) {
+		assert.ok(fooBarBaz === moduleObject, 'default export should be the passed object');
 
 		try {
 			fooBarBaz.def = 'uvw';
-			QUnit.equal(fooBarBaz.def, 'uvw', 'should be able to set a property on the default export object');
+			assert.equal(fooBarBaz.def, 'uvw', 'should be able to set a property on the default export object');
 		} catch(e) {
-			QUnit.ok(false, 'error setting a property on the default export object: ' + e);
+			assert.ok(false, 'error setting a property on the default export object: ' + e);
 		}
 
-		QUnit.start();
-		removeMyself();
+		done();
 	} else {
 		console.log('fooBarBaz === moduleObject:', fooBarBaz === moduleObject);
 

--- a/test/ext-steal-clone/fetch-cache/index.html
+++ b/test/ext-steal-clone/fetch-cache/index.html
@@ -1,7 +1,7 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
 		src='../../../steal.js'

--- a/test/ext-steal-clone/fetch-cache/main.js
+++ b/test/ext-steal-clone/fetch-cache/main.js
@@ -1,5 +1,4 @@
 var stealClone = require('steal-clone');
-var loader = require('@loader');
 
 // test when parent of injected module has been imported prior to cloning
 var origModuleA = require('ext-steal-clone/fetch-cache/moduleA');
@@ -22,12 +21,11 @@ clone.normalize('ext-steal-clone/fetch-cache/moduleA')
 
 	clone.import(normalizedName)
 	.then(function(moduleA) {
-		if (typeof window !== "undefined" && window.QUnit) {
-			QUnit.equal(moduleA.getName(), 'foo mockModuleB', 'import should use source from cache');
-			QUnit.equal(origModuleA.getName(), 'moduleA moduleB', 'prior import should use original dependency');
+		if (typeof window !== "undefined" && window.assert) {
+			assert.equal(moduleA.getName(), 'foo mockModuleB', 'import should use source from cache');
+			assert.equal(origModuleA.getName(), 'moduleA moduleB', 'prior import should use original dependency');
 
-			QUnit.start();
-			removeMyself();
+			done();
 		} else {
 			console.log('moduleA.getName():', moduleA.getName());
 			console.log('origModuleA.getName():', origModuleA.getName());

--- a/test/ext-steal-clone/leak/index.html
+++ b/test/ext-steal-clone/leak/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/leak/main"></script>
 </body>

--- a/test/ext-steal-clone/leak/main.js
+++ b/test/ext-steal-clone/leak/main.js
@@ -1,8 +1,8 @@
 var clone = require("steal-clone");
 var counter = require("./counter");
 
-if (typeof window !== "undefined" && window.QUnit) {
-	QUnit.equal(counter.getCount(), 0, "initially 0");
+if (typeof window !== "undefined" && window.assert) {
+	assert.equal(counter.getCount(), 0, "initially 0");
 } else {
 	console.log(counter.getCount());
 }
@@ -12,15 +12,12 @@ var loader = clone({
 });
 
 loader["import"]("ext-steal-clone/leak/a").then(function(a){
-	var l = loader;
 	a();
 
-	if (typeof window !== "undefined" && window.QUnit) {
-		QUnit.equal(counter.getCount(), 0, "still should be 0");
-		QUnit.start();
-		removeMyself();
+	if (typeof window !== "undefined" && window.assert) {
+		assert.equal(counter.getCount(), 0, "still should be 0");
+		done();
 	} else {
 		console.log(counter.getCount());
 	}
-
 });

--- a/test/ext-steal-clone/multiple-overrides/index.html
+++ b/test/ext-steal-clone/multiple-overrides/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/multiple-overrides/main"></script>
 </body>

--- a/test/ext-steal-clone/multiple-overrides/main.js
+++ b/test/ext-steal-clone/multiple-overrides/main.js
@@ -1,6 +1,4 @@
 var stealClone = require('steal-clone');
-var loader = require('@loader');
-
 var origModuleA = require('ext-steal-clone/multiple-overrides/moduleA');
 
 var clone = stealClone({
@@ -18,12 +16,11 @@ var clone = stealClone({
 
 clone.import('ext-steal-clone/multiple-overrides/moduleA')
   .then(function(moduleA) {
-    if (typeof window !== "undefined" && window.QUnit) {
-      QUnit.equal(moduleA.getName(), 'moduleA mockModuleB mockModuleC', 'import should use injected dependency');
-      QUnit.equal(origModuleA.getName(), 'moduleA moduleB moduleC', 'prior import should use original dependency');
+    if (typeof window !== "undefined" && window.assert) {
+      assert.equal(moduleA.getName(), 'moduleA mockModuleB mockModuleC', 'import should use injected dependency');
+      assert.equal(origModuleA.getName(), 'moduleA moduleB moduleC', 'prior import should use original dependency');
 
-      QUnit.start();
-      removeMyself();
+      done();
     } else {
       console.log('moduleA.getName():', moduleA.getName());
       console.log('origModuleA.getName():', origModuleA.getName());

--- a/test/ext-steal-clone/npm-extension/index.html
+++ b/test/ext-steal-clone/npm-extension/index.html
@@ -1,7 +1,7 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
 		src="../../../steal.js"

--- a/test/ext-steal-clone/npm-extension/main.js
+++ b/test/ext-steal-clone/npm-extension/main.js
@@ -9,11 +9,10 @@ stealClone({
 })
 .import('steal/test/ext-steal-clone/npm-extension/moduleA')
 .then(function(moduleA) {
-  if (typeof window !== "undefined" && window.QUnit) {
-    QUnit.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
+  if (typeof window !== "undefined" && window.assert) {
+    assert.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
 
-    QUnit.start();
-    removeMyself();
+    done();
   } else {
     console.log('moduleA.getName():', moduleA.getName());
   }

--- a/test/ext-steal-clone/prior-import/index.html
+++ b/test/ext-steal-clone/prior-import/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/prior-import/main"></script>
 </body>

--- a/test/ext-steal-clone/prior-import/main.js
+++ b/test/ext-steal-clone/prior-import/main.js
@@ -1,5 +1,4 @@
 var stealClone = require('steal-clone');
-var loader = require('@loader');
 
 // test when parent of injected module has been imported prior to cloning
 var origModuleA = require('ext-steal-clone/prior-import/moduleA');
@@ -14,12 +13,11 @@ var clone = stealClone({
 
 clone.import('ext-steal-clone/prior-import/moduleA')
   .then(function(moduleA) {
-    if (typeof window !== "undefined" && window.QUnit) {
-      QUnit.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
-      QUnit.equal(origModuleA.getName(), 'moduleA moduleB', 'prior import should use original dependency');
+    if (typeof window !== "undefined" && window.assert) {
+      assert.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
+      assert.equal(origModuleA.getName(), 'moduleA moduleB', 'prior import should use original dependency');
 
-      QUnit.start();
-      removeMyself();
+      done();
     } else {
       console.log('moduleA.getName():', moduleA.getName());
       console.log('origModuleA.getName():', origModuleA.getName());

--- a/test/ext-steal-clone/relative-import/index.html
+++ b/test/ext-steal-clone/relative-import/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/relative-import/main"></script>
 </body>

--- a/test/ext-steal-clone/relative-import/main.js
+++ b/test/ext-steal-clone/relative-import/main.js
@@ -3,11 +3,10 @@ var stealClone = require('steal-clone');
 return stealClone()
 .import('ext-steal-clone/relative-import/moduleA')
 .then(function(moduleA) {
-  if (typeof window !== "undefined" && window.QUnit) {
-    QUnit.equal(moduleA.getName(), 'moduleA moduleB', 'import should use injected dependency');
+  if (typeof window !== "undefined" && window.assert) {
+    assert.equal(moduleA.getName(), 'moduleA moduleB', 'import should use injected dependency');
 
-    QUnit.start();
-    removeMyself();
+    done();
   } else {
     console.log('moduleA.getName():', moduleA.getName());
   }

--- a/test/ext-steal-clone/relative-override/index.html
+++ b/test/ext-steal-clone/relative-override/index.html
@@ -1,10 +1,10 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
 	</script>
 	<script type="text/javascript"
-		src='../../../steal.js'
+		src="../../../steal.js"
 		data-config="../../config.js"
 		data-main="ext-steal-clone/relative-override/main"></script>
 </body>

--- a/test/ext-steal-clone/relative-override/main.js
+++ b/test/ext-steal-clone/relative-override/main.js
@@ -9,11 +9,10 @@ return stealClone({
 })
 .import('ext-steal-clone/relative-override/moduleA')
 .then(function(moduleA) {
-  if (typeof window !== "undefined" && window.QUnit) {
-    QUnit.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
+  if (typeof window !== "undefined" && window.assert) {
+    assert.equal(moduleA.getName(), 'moduleA mockModuleB', 'import should use injected dependency');
 
-    QUnit.start();
-    removeMyself();
+    done();
   } else {
     console.log('moduleA.getName():', moduleA.getName());
   }

--- a/test/steal_clone_test.js
+++ b/test/steal_clone_test.js
@@ -1,0 +1,49 @@
+var QUnit = require("steal-qunit");
+var makeIframe = require("./make_iframe");
+var supportsES = require("./supports_proto")();
+
+QUnit.module("steal-clone extension tests");
+
+QUnit.test("basics work", function(assert) {
+	makeIframe("ext-steal-clone/basics/index.html", assert);
+});
+
+QUnit.test("does not share the module registry and extensions with cloned loader", function(assert) {
+	makeIframe("ext-steal-clone/config-separation/index.html", assert);
+});
+
+QUnit.test("allows you to override a module with a default export", function(assert) {
+	makeIframe("ext-steal-clone/default-export-usedefault/index.html", assert);
+});
+
+QUnit.test("allows you to override a module with a default export without setting __useDefault", function(assert) {
+	makeIframe("ext-steal-clone/default-export/index.html", assert);
+});
+
+QUnit.test("caches source of parent modules to avoid duplicate downloads", function(assert) {
+	makeIframe("ext-steal-clone/fetch-cache/index.html", assert);
+});
+
+QUnit.test("works when overriding multiple modules", function(assert) {
+	makeIframe("ext-steal-clone/multiple-overrides/index.html", assert);
+});
+
+(supportsES ? QUnit.test : QUnit.skip)("works when using the npm extensions", function(assert) {
+	makeIframe("ext-steal-clone/npm-extension/index.html", assert);
+});
+
+QUnit.test("works when a parent of injected dependency has been imported", function(assert) {
+	makeIframe("ext-steal-clone/prior-import/index.html", assert);
+});
+
+QUnit.test("works when using relative imports", function(assert) {
+	makeIframe("ext-steal-clone/relative-import/index.html", assert);
+});
+
+QUnit.test("works when using relative overrides", function(assert) {
+	makeIframe("ext-steal-clone/relative-override/index.html", assert);
+});
+
+QUnit.test("what happens within a cloned loader should not leak", function(assert) {
+	makeIframe("ext-steal-clone/leak/index.html", assert);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ require('src/trace/trace_test');
 require('test/config/config_test');
 require('test/clone/clone_test');
 require("test/babel_plugins_test");
+require("test/steal_clone_test");
 
 QUnit.module("steal via system import");
 
@@ -432,54 +433,6 @@ QUnit.module("steal via system import");
 
 	asyncTest("Basics work", function(){
 		makeIframe("contextual/test.html");
-	});
-
-	QUnit.module("ext-steal-clone")
-
-	asyncTest("basics work", function() {
-		makeIframe("ext-steal-clone/basics/index.html");
-	});
-
-	asyncTest("does not share the module registry and extensions with cloned loader", function() {
-		makeIframe("ext-steal-clone/config-separation/index.html");
-	});
-
-	asyncTest("allows you to override a module with a default export", function() {
-		makeIframe("ext-steal-clone/default-export-usedefault/index.html");
-	});
-
-	asyncTest("allows you to override a module with a default export without setting __useDefault", function() {
-		makeIframe("ext-steal-clone/default-export/index.html");
-	});
-
-	asyncTest("caches source of parent modules to avoid duplicate downloads", function() {
-		makeIframe("ext-steal-clone/fetch-cache/index.html");
-	});
-
-	asyncTest("works when overriding multiple modules", function() {
-		makeIframe("ext-steal-clone/multiple-overrides/index.html");
-	});
-
-	if(supportsES) {
-		asyncTest("works when using the npm extensions", function() {
-			makeIframe("ext-steal-clone/npm-extension/index.html");
-		});
-	}
-
-	asyncTest("works when a parent of injected dependency has been imported", function() {
-		makeIframe("ext-steal-clone/prior-import/index.html");
-	});
-
-	asyncTest("works when using relative imports", function() {
-		makeIframe("ext-steal-clone/relative-import/index.html");
-	});
-
-	asyncTest("works when using relative overrides", function() {
-		makeIframe("ext-steal-clone/relative-override/index.html");
-	});
-
-	asyncTest("what happens within a cloned loader should not leak", function(){
-		makeIframe("ext-steal-clone/leak/index.html");
 	});
 
 	QUnit.module("nw.js");


### PR DESCRIPTION
Seemed like the perfect candidate to move out of the main test file

- Remove `asyncTest` in favor of QUnit's async workflow