### PR TITLE
Allow @/ to work the same as ~/

### DIFF
--- a/docs/scheme-tilde.md
+++ b/docs/scheme-tilde.md
@@ -1,4 +1,4 @@
-@property tilde ~
+@property tilde ~ or @
 @parent StealJS.schemes
 
 A lookup scheme that roots module lookup to your project's base folder, either your `steal.directories.lib` folder or the [config.baseURL].
@@ -7,9 +7,10 @@ This syntax is supported by all module formats.
 
 ## Use
 
-Prepend lookups with `~/` such as:
+Prepend lookups with `~/` or `@/` such as:
 
     var tabs = require("~/components/tabs/tabs");
+    var tabs = require("@/components/tabs/tabs");
 
 This will load the module from `BASE/components/tabs/tabs.js`. If your package.json has:
 
@@ -26,7 +27,7 @@ Then it will be loaded from `BASE/src/components/tabs/tabs.js`.
 
 ## Alternatives
 
-The **~** scheme is an alternative to using the package name for look up, such as:
+The **~** or **@** scheme is an alternative to using the package name for look up, such as:
 
      {
 	   "name": "app"

--- a/ext/npm-utils.js
+++ b/ext/npm-utils.js
@@ -554,7 +554,7 @@ var utils = {
 			return  path.substr(0,1) === ".";
 		},
 		startsWithTildeSlash: function( path ) {
-			return path.substr(0,2) === "~/";
+			return path.substr(0,2) === "~/" || path.substr(0,2) === "@/";
 		},
 		joinURIs: function(base, href) {
 			function removeDotSegments(input) {

--- a/test/npm/test.js
+++ b/test/npm/test.js
@@ -86,6 +86,19 @@ QUnit.test("meta", function(assert) {
 		});
 });
 
+QUnit.test("@/ works the same as ~/", function(assert) {
+	var done = assert.async();
+
+	GlobalSystem["import"]("@/meta")
+		.then(function(meta) {
+			assert.equal(meta, "123", "got 123");
+		})
+		.then(done, function(err) {
+			assert.notOk(err, "should not fail");
+			done();
+		});
+});
+
 QUnit.test("module names that start with @", function(assert) {
 	var done = assert.async();
 


### PR DESCRIPTION
This allows modules beginning with `@/` to resolve the same as `~/`.

Webpack projects use `@/` the same as our `~/` operator.   Webpack doesn't allow working in modlets, so I saw a good opportunity to promote Steal as a tool to use together with webpack.  I'm going to be posting an article in the Vue.js forums on how its preferable to use Steal during development because it allows working in modlets. (Vue.js's CLI builds webpack projects)  Making `@/` work is the last requirement to making the workflow perfect.