### PR TITLE
Use pluginLoader in contextual extension

### DIFF
--- a/src/system-extension-contextual.js
+++ b/src/system-extension-contextual.js
@@ -8,6 +8,7 @@ addStealExtension(function (loader) {
   var normalize = loader.normalize;
   loader.normalize = function(name, parentName){
     var loader = this;
+	var pluginLoader = loader.pluginLoader || loader;
 
     if (parentName) {
       var definer = this._contextualModules[name];
@@ -19,7 +20,7 @@ addStealExtension(function (loader) {
         if(!loader.has(name)) {
           // `definer` could be a function or could be a moduleName
           if (typeof definer === 'string') {
-            definer = loader['import'](definer);
+            definer = pluginLoader['import'](definer);
           }
 
           return Promise.resolve(definer)


### PR DESCRIPTION
If a contextual module is defined passing a string as the `definer` parameter, the `pluginLoader` needs to be used to dynamically load the `definer` function; otherwise steal-tools won't build the app.

Fixes this test https://travis-ci.org/stealjs/steal-tools/jobs/218230746#L1302
Closes #952

