### PR TITLE
Prevent unwanted global package name loading

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -162,7 +162,7 @@ var crawl = {
 		return npmLoad(context, childPkg, requestedVersion)
 		.then(function(pkg){
 			crawl.setVersionsConfig(context, pkg, requestedVersion);
-			crawl.setParent(context, pkg, isRoot);
+			crawl.setParent(context, pkg, false);
 			return pkg;
 		});
 	},


### PR DESCRIPTION
In #1117 we made it so that we fetch a package by name even if not a direct dependency. However, this can cause unwanted loading in the case where a child package has a devDependency (which will not be downloaded to node_modules). This prevents loading such devDependencies. Closes #1145

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
