### PR TITLE
Remove qunit (node) dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "jquery": "^3.1.1",
     "jquery-ui": "1.10.5",
     "live-reload-testing": "^6.0.0",
-    "qunit": "^0.9.3",
     "qunitjs": "^1.17.1",
     "regenerator-runtime": "^0.10.3",
     "release": "^1.1.7",


### PR DESCRIPTION
There are no node qunit tests

Close https://github.com/stealjs/steal/pull/1096 after merging. 
