### PR TITLE
Call dispose callback when disposing a module

### DIFF
--- a/ext/live-reload.js
+++ b/ext/live-reload.js
@@ -114,8 +114,8 @@ function disposeModule(moduleName, emitter, inModList){
 }
 
 // Teardown a module name by deleting it and all of its parent modules.
-function teardown(moduleName, e, moduleNames) {
-	var moduleNames = moduleNames || {};
+function teardown(moduleName, e, inModuleNames) {
+	var moduleNames = inModuleNames || {};
 
 	if(disposeModule(moduleName, e, moduleNames)) {
 		// Delete the module and call teardown on its parents as well.
@@ -155,8 +155,8 @@ function makeReload(moduleName, listeners){
 	reload.once = bind(e.once, e);
 
 	// This allows modules to dispose themselves
-	reload.dispose = function(moduleName, cb){
-		var name = moduleName;
+	reload.dispose = function(disposingModuleName, cb){
+		var name = disposingModuleName;
 		var callback = cb;
 		if(!callback) {
 			callback = name;

--- a/test/live_reload/unit.js
+++ b/test/live_reload/unit.js
@@ -182,6 +182,22 @@ QUnit.module("reload.dispose", {
 	}
 });
 
+QUnit.test("allows modules to dispose themselves", function(assert){
+	var done = assert.async();
+
+	loader.set("foo", loader.newModule({}));
+
+	loader.import("live-reload", { name: "foo" })
+	.then(function(reload){
+		reload.dispose(function(){
+			assert.ok(true, "this dispose was called");
+		});
+
+		return reloader("foo");
+	})
+	.then(done, done);
+});
+
 QUnit.test("disposes only the modules that it should", function(assert){
 	var done = assert.async();
 

--- a/test/npm/load_test.js
+++ b/test/npm/load_test.js
@@ -62,6 +62,7 @@ QUnit.test("Configuration is reapplied after a live-reload", function(assert){
 		.allowFetch("live-reload");
 
 	var loader = runner.loader;
+	loader.paths["live-reload"] = "ext/live-reload.js";
 
 	helpers.init(loader)
 	.then(function(){

--- a/test/saucelabs.js
+++ b/test/saucelabs.js
@@ -5,11 +5,11 @@ var testPagesUrls = require('./test-pages-urls');
 var platforms = [{
 	browserName: 'firefox',
 	platform: 'Windows 10',
-	version: '50.0'
+	version: '52.0'
 }, {
 	browserName: 'firefox',
 	platform: 'OS X 10.11',
-	version: '50.0'
+	version: '52.0'
 }, {
 	browserName: 'googlechrome',
 	platform: 'Windows 10'


### PR DESCRIPTION
When using the simple signature for reload.dispose:

```js
reload.dispose(function(){
 // teardown stuff here
});
```

Support this by firing the dispose event on the correct module; the contextual module using `reload`.

Closes #1172

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
