### PR TITLE
Restructure npm normalize tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       script: npm run test-node:ci
     - node_js: 6
       script: npm run test-node:ci
-    - node_js: node
+    - node_js: 7
       addons:
         sauce_connect: true
       before_script:

--- a/test/npm/normalize_main-config_test.js
+++ b/test/npm/normalize_main-config_test.js
@@ -1,0 +1,227 @@
+var helpers = require("./helpers")(System);
+var Package = helpers.Package;
+var utils = require("../../ext/npm-utils");
+
+QUnit.module("npm normalize - 'main' config variations");
+
+var mainVariations = {
+	"steal.main": function(pkg){
+		pkg.steal = {
+			main: "bar"
+		};
+	},
+	"system.main": function(pkg){
+		pkg.system = {
+			main: "bar"
+		};
+	},
+
+	"pkg.main": function(pkg){
+		pkg.main = "bar.js";
+	},
+
+	"browser string": function(pkg){
+		pkg.browser = "bar.js";
+	},
+
+	"browser string ending with slash": function(pkg){
+		pkg.browser = "bar/";
+		return "bar/index";
+	},
+
+	"browserify string": function(pkg){
+		pkg.browserify = "bar";
+	},
+
+	"jam.main": function(pkg){
+		pkg.jam = {
+			main: "./bar.js"
+		};
+	}
+};
+
+Object.keys(mainVariations).forEach(function(testName){
+	var definer = mainVariations[testName];
+
+	QUnit.test(testName, function(assert){
+		var done = assert.async();
+
+		var deepPackageJSON = {
+			name: "deep",
+			main: "foo.js",
+			version: "1.0.0",
+		};
+		var modulePath = definer(deepPackageJSON) || "bar";
+
+		var loader = helpers.clone()
+			.npmVersion(3)
+			.rootPackage({
+				name: "parent",
+				main: "main.js",
+				version: "1.0.0",
+				dependencies: {
+					"child": "1.0.0"
+				}
+			})
+			.withPackages([
+				new Package({
+					name: "child",
+					main: "main.js",
+					version: "1.0.0",
+					dependencies: {
+						"deep": "1.0.0"
+					}
+				}).deps([
+					deepPackageJSON
+				])
+			])
+			.loader;
+
+		helpers.init(loader)
+		.then(function(){
+			return loader.normalize("child", "parent@1.0.0#main");
+		})
+		.then(function(){
+			return loader.normalize("deep", "child@1.0.0#main");
+		})
+		.then(function(name){
+			assert.equal(name, "deep@1.0.0#" + modulePath, "Correctly normalized");
+		})
+		.then(done, done);
+	});
+});
+
+QUnit.test("A package's steal.main is retained when loading dependant packages", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js",
+			dependencies: {
+				parent: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "parent",
+				main: "main.js",
+				version: "1.0.0",
+				system: {
+					main: "other.js",
+					map: {
+						"child/a": "child/b"
+					}
+				},
+				dependencies: {
+					child: "1.0.0"
+				}
+			},
+			{
+				name: "child",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("parent", "app@1.0.0#main");
+	})
+	.then(function(){
+		loader.npmContext.resavePackageInfo = true;
+
+		return loader.normalize("child", "parent@1.0.0#other");
+	})
+	.then(function(name){
+		var pkgs = loader.npmContext.pkgInfo;
+		var pkg = utils.filter(pkgs, function(p) { return p.name === "parent"; })[0];
+		assert.equal(pkg.steal.main, "other.js");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("A dependency can load its devDependencies if they happen to exist", function(assert){
+	var done = assert.async();
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				foo: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "foo",
+				main: "main.js",
+				version: "1.0.0",
+				devDependencies: {
+					bar: "1.0.0"
+				}
+			},
+			{
+				name: "bar",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("foo", "app@1.0.0#main");
+	})
+	.then(function(){
+		return loader.normalize("bar", "foo@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "bar@1.0.0#main");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("A dependency's devDependencies are not fetched when in 'plugins'", function(assert){
+	var done = assert.async();
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				foo: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "foo",
+				main: "main.js",
+				version: "1.0.0",
+				devDependencies: {
+					bar: "1.0.0"
+				},
+				steal: {
+					plugins: ["bar"]
+				}
+			},
+			{
+				name: "bar",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("foo", "app@1.0.0#main");
+	})
+	.then(function(name){
+		var pkg = loader.npmPaths["./node_modules/bar"];
+		assert.equal(pkg, undefined, "This should not be fetched");
+	})
+	.then(done, helpers.fail(assert, done));
+});

--- a/test/npm/normalize_plugins-config_test.js
+++ b/test/npm/normalize_plugins-config_test.js
@@ -1,0 +1,149 @@
+
+QUnit.module("npm normalize - 'plugins' config");
+
+QUnit.test("Works from the root package", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js",
+			dependencies: {
+				dep: "1.0.0"
+			},
+			steal: {
+				plugins: ["dep"]
+			}
+		})
+		.withPackages([
+			{
+				name: "dep",
+				version: "1.0.0",
+				main: "main",
+				steal: {
+					ext: {
+						txt: "dep"
+					}
+				}
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("app/foo.txt", "app@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "app@1.0.0#foo.txt!dep@1.0.0#main");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("Works from a dependent package", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js",
+			dependencies: {
+				dep: "1.0.0"
+			},
+			steal: {
+				plugins: ["dep"]
+			}
+		})
+		.withPackages([
+			{
+				name: "dep",
+				version: "1.0.0",
+				main: "main.js",
+				dependencies: {
+					other: "1.0.0"
+				},
+				steal: {
+					plugins: ["other"]
+				}
+			},
+			{
+				name: "other",
+				version: "1.0.0",
+				main: "main.js",
+				steal: {
+					ext: {
+						txt: "other"
+					}
+				}
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("dep/foo.txt", "app@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "dep@1.0.0#foo.txt!other@1.0.0#main");
+	})
+	.then(done, helpers.fail(assert, done));
+
+});
+
+QUnit.test("Works from a dependent package that is progressively loaded", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js",
+			dependencies: {
+				dep: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "dep",
+				version: "1.0.0",
+				main: "main.js",
+				dependencies: {
+					other: "1.0.0"
+				},
+				steal: {
+					plugins: ["other"]
+				}
+			},
+			{
+				name: "other",
+				version: "1.0.0",
+				main: "main.js",
+				steal: {
+					ext: {
+						txt: "other"
+					}
+				}
+			}
+		])
+		.loader;
+
+	var fetch = loader.fetch;
+	loader.fetch = function(){
+		return Promise.resolve(fetch.apply(this, arguments))
+			.then(null, function(err){
+				assert.ok(false, err.message);
+				return Promise.reject(err);
+			});
+	};
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("dep/foo.txt", "app@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "dep@1.0.0#foo.txt!other@1.0.0#main");
+	})
+	.then(done, helpers.fail(assert, done));
+
+});

--- a/test/npm/normalize_plugins-config_test.js
+++ b/test/npm/normalize_plugins-config_test.js
@@ -1,3 +1,4 @@
+var helpers = require("./helpers")(System);
 
 QUnit.module("npm normalize - 'plugins' config");
 

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -1,6 +1,5 @@
 var helpers = require("./helpers")(System);
 var Package = helpers.Package;
-var utils = require("../../ext/npm-utils");
 
 require("./normalize_main-config_test");
 require("./normalize_plugins-config_test");

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -2,7 +2,10 @@ var helpers = require("./helpers")(System);
 var Package = helpers.Package;
 var utils = require("../../ext/npm-utils");
 
-QUnit.module("normalizing");
+require("./normalize_main-config_test");
+require("./normalize_plugins-config_test");
+
+QUnit.module("npm normalize - various");
 
 QUnit.test("basics", function(assert){
 	var done = assert.async();
@@ -839,374 +842,37 @@ QUnit.test("descriptive version mismatch error (#1176)", function(assert) {
 		.then(done, helpers.fail(assert, done));
 });
 
-QUnit.module("normalizing with main config");
-
-var mainVariations = {
-	"steal.main": function(pkg){
-		pkg.steal = {
-			main: "bar"
-		};
-	},
-	"system.main": function(pkg){
-		pkg.system = {
-			main: "bar"
-		};
-	},
-
-	"pkg.main": function(pkg){
-		pkg.main = "bar.js";
-	},
-
-	"browser string": function(pkg){
-		pkg.browser = "bar.js";
-	},
-
-	"browser string ending with slash": function(pkg){
-		pkg.browser = "bar/";
-		return "bar/index";
-	},
-
-	"browserify string": function(pkg){
-		pkg.browserify = "bar";
-	},
-
-	"jam.main": function(pkg){
-		pkg.jam = {
-			main: "./bar.js"
-		};
-	}
-};
-
-Object.keys(mainVariations).forEach(function(testName){
-	var definer = mainVariations[testName];
-
-	QUnit.test(testName, function(assert){
-		var done = assert.async();
-
-		var deepPackageJSON = {
-			name: "deep",
-			main: "foo.js",
-			version: "1.0.0",
-		};
-		var modulePath = definer(deepPackageJSON) || "bar";
-
-		var loader = helpers.clone()
-			.npmVersion(3)
-			.rootPackage({
-				name: "parent",
-				main: "main.js",
-				version: "1.0.0",
-				dependencies: {
-					"child": "1.0.0"
-				}
-			})
-			.withPackages([
-				new Package({
-					name: "child",
-					main: "main.js",
-					version: "1.0.0",
-					dependencies: {
-						"deep": "1.0.0"
-					}
-				}).deps([
-					deepPackageJSON
-				])
-			])
-			.loader;
-
-		helpers.init(loader)
-		.then(function(){
-			return loader.normalize("child", "parent@1.0.0#main");
-		})
-		.then(function(){
-			return loader.normalize("deep", "child@1.0.0#main");
-		})
-		.then(function(name){
-			assert.equal(name, "deep@1.0.0#" + modulePath, "Correctly normalized");
-		})
-		.then(done, done);
-	});
-});
-
-QUnit.test("A package's steal.main is retained when loading dependant packages", function(assert){
+QUnit.skip("'map' configuration where the right-hand identifier is an npm package but the left is not", function(assert){
 	var done = assert.async();
 
-	var loader = helpers.clone()
-		.rootPackage({
-			name: "app",
-			version: "1.0.0",
-			main: "main.js",
-			dependencies: {
-				parent: "1.0.0"
-			}
-		})
-		.withPackages([
-			{
-				name: "parent",
-				main: "main.js",
-				version: "1.0.0",
-				system: {
-					main: "other.js",
-					map: {
-						"child/a": "child/b"
-					}
-				},
-				dependencies: {
-					child: "1.0.0"
-				}
-			},
-			{
-				name: "child",
-				main: "main.js",
-				version: "1.0.0"
-			}
-		])
-		.loader;
-
-	helpers.init(loader)
-	.then(function(){
-		return loader.normalize("parent", "app@1.0.0#main");
-	})
-	.then(function(){
-		loader.npmContext.resavePackageInfo = true;
-
-		return loader.normalize("child", "parent@1.0.0#other");
-	})
-	.then(function(name){
-		var pkgs = loader.npmContext.pkgInfo;
-		var pkg = utils.filter(pkgs, function(p) { return p.name === "parent" })[0];
-		assert.equal(pkg.steal.main, "other.js");
-	})
-	.then(done, helpers.fail(assert, done));
-});
-
-QUnit.test("A dependency can load its devDependencies if they happen to exist", function(assert){
-	var done = assert.async();
 	var loader = helpers.clone()
 		.rootPackage({
 			name: "app",
 			main: "main.js",
 			version: "1.0.0",
 			dependencies: {
-				foo: "1.0.0"
-			}
-		})
-		.withPackages([
-			{
-				name: "foo",
-				main: "main.js",
-				version: "1.0.0",
-				devDependencies: {
-					bar: "1.0.0"
-				}
-			},
-			{
-				name: "bar",
-				main: "main.js",
-				version: "1.0.0"
-			}
-		])
-		.loader;
-
-	helpers.init(loader)
-	.then(function(){
-		return loader.normalize("foo", "app@1.0.0#main");
-	})
-	.then(function(){
-		return loader.normalize("bar", "foo@1.0.0#main");
-	})
-	.then(function(name){
-		assert.equal(name, "bar@1.0.0#main");
-	})
-	.then(done, helpers.fail(assert, done));
-});
-
-QUnit.test("A dependency's devDependencies are not fetched when in 'plugins'", function(assert){
-	var done = assert.async();
-	var loader = helpers.clone()
-		.rootPackage({
-			name: "app",
-			main: "main.js",
-			version: "1.0.0",
-			dependencies: {
-				foo: "1.0.0"
-			}
-		})
-		.withPackages([
-			{
-				name: "foo",
-				main: "main.js",
-				version: "1.0.0",
-				devDependencies: {
-					bar: "1.0.0"
-				},
-				steal: {
-					plugins: ["bar"]
-				}
-			},
-			{
-				name: "bar",
-				main: "main.js",
-				version: "1.0.0"
-			}
-		])
-		.loader;
-
-	helpers.init(loader)
-	.then(function(){
-		return loader.normalize("foo", "app@1.0.0#main");
-	})
-	.then(function(name){
-		var pkg = loader.npmPaths["./node_modules/bar"];
-		assert.equal(pkg, undefined, "This should not be fetched");
-	})
-	.then(done, helpers.fail(assert, done));
-});
-
-QUnit.module("plugins configuration");
-
-QUnit.test("Works from the root package", function(assert){
-	var done = assert.async();
-
-	var loader = helpers.clone()
-		.rootPackage({
-			name: "app",
-			version: "1.0.0",
-			main: "main.js",
-			dependencies: {
-				dep: "1.0.0"
+				mapped: "1.0.0"
 			},
 			steal: {
-				plugins: ["dep"]
+				map: {
+					dep: "mapped"
+				}
 			}
 		})
 		.withPackages([
 			{
-				name: "dep",
-				version: "1.0.0",
-				main: "main",
-				steal: {
-					ext: {
-						txt: "dep"
-					}
-				}
+				name: "mapped",
+				main: "main.js",
+				version: "1.0.0"
 			}
 		])
 		.loader;
 
-	helpers.init(loader)
-	.then(function(){
-		return loader.normalize("app/foo.txt", "app@1.0.0#main");
+	helpers.init(loader).then(function(){
+		return loader.normalize("dep", "app@1.0.0#main");
 	})
 	.then(function(name){
-		assert.equal(name, "app@1.0.0#foo.txt!dep@1.0.0#main");
-	})
-	.then(done, helpers.fail(assert, done));
-});
-
-QUnit.test("Works from a dependent package", function(assert){
-	var done = assert.async();
-
-	var loader = helpers.clone()
-		.rootPackage({
-			name: "app",
-			version: "1.0.0",
-			main: "main.js",
-			dependencies: {
-				dep: "1.0.0"
-			},
-			steal: {
-				plugins: ["dep"]
-			}
-		})
-		.withPackages([
-			{
-				name: "dep",
-				version: "1.0.0",
-				main: "main.js",
-				dependencies: {
-					other: "1.0.0"
-				},
-				steal: {
-					plugins: ["other"]
-				}
-			},
-			{
-				name: "other",
-				version: "1.0.0",
-				main: "main.js",
-				steal: {
-					ext: {
-						txt: "other"
-					}
-				}
-			}
-		])
-		.loader;
-
-	helpers.init(loader)
-	.then(function(){
-		return loader.normalize("dep/foo.txt", "app@1.0.0#main");
-	})
-	.then(function(name){
-		assert.equal(name, "dep@1.0.0#foo.txt!other@1.0.0#main");
-	})
-	.then(done, helpers.fail(assert, done));
-
-});
-
-QUnit.test("Works from a dependent package that is progressively loaded", function(assert){
-	var done = assert.async();
-
-	var loader = helpers.clone()
-		.rootPackage({
-			name: "app",
-			version: "1.0.0",
-			main: "main.js",
-			dependencies: {
-				dep: "1.0.0"
-			}
-		})
-		.withPackages([
-			{
-				name: "dep",
-				version: "1.0.0",
-				main: "main.js",
-				dependencies: {
-					other: "1.0.0"
-				},
-				steal: {
-					plugins: ["other"]
-				}
-			},
-			{
-				name: "other",
-				version: "1.0.0",
-				main: "main.js",
-				steal: {
-					ext: {
-						txt: "other"
-					}
-				}
-			}
-		])
-		.loader;
-
-	var fetch = loader.fetch;
-	loader.fetch = function(){
-		return Promise.resolve(fetch.apply(this, arguments))
-			.then(null, function(err){
-				assert.ok(false, err.message);
-				return Promise.reject(err);
-			});
-	};
-
-	helpers.init(loader)
-	.then(function(){
-		return loader.normalize("dep/foo.txt", "app@1.0.0#main");
-	})
-	.then(function(name){
-		assert.equal(name, "dep@1.0.0#foo.txt!other@1.0.0#main");
+		assert.equal(name, "mapped@1.0.0#main");
 	})
 	.then(done, helpers.fail(assert, done));
 });


### PR DESCRIPTION
This restructures the npm normalize tests, putting the different
QUnit.modules into their own test files to make it easier to add new
tests.

Also adds a breaking test for #1208 (currently skipped)