### PR TITLE
Make the live-reload extension cloneable

### DIFF
--- a/ext/live-reload.js
+++ b/ext/live-reload.js
@@ -1,10 +1,6 @@
 var loader = require("@loader");
 var steal = require("@steal");
 
-// This is a map of listeners, those who have registered reload callbacks.
-loader._liveListeners = {};
-loader.liveReloadInstalled = true;
-
 // A simple emitter
 function E () {
 	// Keep this empty so it's easier to inherit from
@@ -72,253 +68,265 @@ E.prototype = {
 	}
 };
 
-// Our instance
-loader._liveEmitter = new E();
-
-// Put a hook on `normalize` so we can keep a reverse map of modules to parents.
-// We'll use this to recursively reload modules.
-var normalize = loader.normalize;
-loader.normalize = function(identifier, parentName){
-	var loader = this;
-	var name = identifier;
-
-	if(name === "live-reload") {
-		name = "live-reload/" + parentName;
-		if(!loader.has(name)) {
-			loader.set(name, loader.newModule({
-				default: makeReload(parentName),
-				__useDefault: true
-			}));
-		}
-		return name;
+function addLiveReload(loader) {
+	if(loader._extensions) {
+		loader._extensions.push(addLiveReload);
 	}
 
-	return normalize.apply(this, arguments);
-};
+	// This is a map of listeners, those who have registered reload callbacks.
+	loader._liveListeners = {};
+	loader.liveReloadInstalled = true;
 
-function disposeModule(moduleName, emitter, inModList){
-	var moduleList = inModList || {};
+	// Our instance
+	loader._liveEmitter = new E();
 
-	var mod = loader.get(moduleName);
-	if(mod) {
-		moduleList[moduleName] = true;
-		emitter.emit("!dispose/" + moduleName);
-		loader.delete(moduleName);
-		if(loader._liveListeners[moduleName]) {
-			loader.delete("live-reload/" + moduleName);
-			delete loader._liveListeners[moduleName];
+	// Put a hook on `normalize` so we can keep a reverse map of modules to parents.
+	// We'll use this to recursively reload modules.
+	var normalize = loader.normalize;
+	loader.normalize = function(identifier, parentName){
+		var loader = this;
+		var name = identifier;
+
+		if(name === "live-reload") {
+			name = "live-reload/" + parentName;
+			if(!loader.has(name)) {
+				loader.set(name, loader.newModule({
+					default: makeReload(parentName),
+					__useDefault: true
+				}));
+			}
+			return name;
 		}
-		return true;
-	}
-	return false;
-}
 
-// Teardown a module name by deleting it and all of its parent modules.
-function teardown(moduleName, e, inModuleNames) {
-	var moduleNames = inModuleNames || {};
-
-	if(disposeModule(moduleName, e, moduleNames)) {
-		// Delete the module and call teardown on its parents as well.
-		var parents = loader.getDependants(moduleName);
-
-		for(var i = 0, len = parents.length; i < len; i++) {
-			teardown(parents[i], e, moduleNames);
-		}
-	}
-
-	return moduleNames;
-}
-
-function makeReload(moduleName, listeners){
-	loader._liveListeners[moduleName] = true;
-	var e = loader._liveEmitter;
-
-	function reload(moduleName, callback){
-		// 3 forms
-		// reload(callback); -> after full cycle
-		// reload("foo", callback); -> after "foo" is imported.
-		// reload("*", callback); -> after each module imports.
-		if(arguments.length === 2) {
-			reload.on(moduleName, callback);
-			setupUnbind(moduleName, callback);
-			return;
-		}
-		reload.on("!cycleComplete", moduleName);
-		setupUnbind("!cycleComplete", moduleName);
-	}
-
-	reload.isReloading = function(){
-		return !!loader._inLiveReloadCycle;
-	};
-	reload.on = bind(e.on, e);
-	reload.off = bind(e.off, e);
-	reload.once = bind(e.once, e);
-
-	// This allows modules to dispose themselves
-	reload.dispose = function(disposingModuleName, cb){
-		var name = disposingModuleName;
-		var callback = cb;
-		if(!callback) {
-			callback = name;
-			name = moduleName;
-		}
-		var event = "!dispose/" + name;
-		reload.on(event, callback);
-		setupUnbind(event, callback);
+		return normalize.apply(this, arguments);
 	};
 
-	// This allows modules to dispose of other modules
-	// This might be needed for cleanup.
-	reload.disposeModule = function(name){
-		disposeModule(name, e);
-	};
+	function disposeModule(moduleName, emitter, inModList){
+		var moduleList = inModList || {};
 
-	function setupUnbind(event, callback){
-		e.once("!dispose/" + moduleName, function(){
-			e.off(event, callback);
-		});
+		var mod = loader.get(moduleName);
+		if(mod) {
+			moduleList[moduleName] = true;
+			emitter.emit("!dispose/" + moduleName);
+			loader.delete(moduleName);
+			if(loader._liveListeners[moduleName]) {
+				loader.delete("live-reload/" + moduleName);
+				delete loader._liveListeners[moduleName];
+			}
+			return true;
+		}
+		return false;
 	}
 
-	return reload;
-}
+	// Teardown a module name by deleting it and all of its parent modules.
+	function teardown(moduleName, e, inModuleNames) {
+		var moduleNames = inModuleNames || {};
 
-function bind(fn, ctx){
-	return fn.bind ? fn.bind(ctx) : function(){
-		return fn.apply(ctx, arguments);
-	};
-}
+		if(disposeModule(moduleName, e, moduleNames)) {
+			// Delete the module and call teardown on its parents as well.
+			var parents = loader.getDependants(moduleName);
 
-function getModuleNames(msg) {
-	var names;
-	try {
-		names = JSON.parse(msg);
-	} catch(ex) {
-		names = [msg];
+			for(var i = 0, len = parents.length; i < len; i++) {
+				teardown(parents[i], e, moduleNames);
+			}
+		}
+
+		return moduleNames;
 	}
-	return names;
-}
 
-function reloadAll(msg) {
-	var moduleNames = getModuleNames(msg);
-	loader._inLiveReloadCycle = true;
-	var promises = [];
-	for(var i = 0, len = moduleNames.length; i < len; i++) {
-		promises.push(reload(moduleNames[i]));
-	}
-	return Promise.all(promises).then(function(){
+	function makeReload(moduleName, listeners){
+		loader._liveListeners[moduleName] = true;
 		var e = loader._liveEmitter;
-		loader._inLiveReloadCycle = false;
-		e.emit("!cycleComplete");
-	});
-}
 
-function reload(moduleName) {
-	var e = loader._liveEmitter;
-	var currentDeps = loader.getDependencies(moduleName) || [];
+		function reload(moduleName, callback){
+			// 3 forms
+			// reload(callback); -> after full cycle
+			// reload("foo", callback); -> after "foo" is imported.
+			// reload("*", callback); -> after each module imports.
+			if(arguments.length === 2) {
+				reload.on(moduleName, callback);
+				setupUnbind(moduleName, callback);
+				return;
+			}
+			reload.on("!cycleComplete", moduleName);
+			setupUnbind("!cycleComplete", moduleName);
+		}
 
-	// Call teardown to recursively delete all parents, then call `import` on the
-	// top-level parents.
-	var moduleNames = teardown(moduleName, e);
+		reload.isReloading = function(){
+			return !!loader._inLiveReloadCycle;
+		};
+		reload.on = bind(e.on, e);
+		reload.off = bind(e.off, e);
+		reload.once = bind(e.once, e);
 
-	var imports = [];
-	function importModule(moduleName){
-		return loader["import"](moduleName).then(function(val){
-			e.emit(moduleName, val);
-			e.emit("*", moduleName, val);
+		// This allows modules to dispose themselves
+		reload.dispose = function(disposingModuleName, cb){
+			var name = disposingModuleName;
+			var callback = cb;
+			if(!callback) {
+				callback = name;
+				name = moduleName;
+			}
+			var event = "!dispose/" + name;
+			reload.on(event, callback);
+			setupUnbind(event, callback);
+		};
+
+		// This allows modules to dispose of other modules
+		// This might be needed for cleanup.
+		reload.disposeModule = function(name){
+			disposeModule(name, e);
+		};
+
+		function setupUnbind(event, callback){
+			e.once("!dispose/" + moduleName, function(){
+				e.off(event, callback);
+			});
+		}
+
+		return reload;
+	}
+
+	function bind(fn, ctx){
+		return fn.bind ? fn.bind(ctx) : function(){
+			return fn.apply(ctx, arguments);
+		};
+	}
+
+	function getModuleNames(msg) {
+		var names;
+		try {
+			names = JSON.parse(msg);
+		} catch(ex) {
+			names = [msg];
+		}
+		return names;
+	}
+
+	function reloadAll(msg) {
+		var moduleNames = getModuleNames(msg);
+		loader._inLiveReloadCycle = true;
+		var promises = [];
+		for(var i = 0, len = moduleNames.length; i < len; i++) {
+			promises.push(reload(moduleNames[i]));
+		}
+		return Promise.all(promises).then(function(){
+			var e = loader._liveEmitter;
+			loader._inLiveReloadCycle = false;
+			e.emit("!cycleComplete");
 		});
 	}
 
-	for(var modName in moduleNames) {
-		imports.push(importModule(modName));
-	}
-	// Once everything is imported call the global listener callback functions.
-	return Promise.all(imports).then(function(){
-		// Remove any newly orphaned modules before declaring the cycle complete.
-		removeOrphans(moduleName, currentDeps);
-	}, function(){
-		// There was an error re-importing modules
-		// Workers don't have a location and no way to refresh the page.
-		if(loader.global.location && loader.global.location.reload) {
-			loader.global.location.reload();
+	function reload(moduleName) {
+		var e = loader._liveEmitter;
+		var currentDeps = loader.getDependencies(moduleName) || [];
+
+		// Call teardown to recursively delete all parents, then call `import` on the
+		// top-level parents.
+		var moduleNames = teardown(moduleName, e);
+
+		var imports = [];
+		function importModule(moduleName){
+			return loader["import"](moduleName).then(function(val){
+				e.emit(moduleName, val);
+				e.emit("*", moduleName, val);
+			});
 		}
-	});
-}
 
-function removeOrphans(moduleName, oldDeps){
-	var deps = loader.getDependencies(moduleName) || [];
+		for(var modName in moduleNames) {
+			imports.push(importModule(modName));
+		}
+		// Once everything is imported call the global listener callback functions.
+		return Promise.all(imports).then(function(){
+			// Remove any newly orphaned modules before declaring the cycle complete.
+			removeOrphans(moduleName, currentDeps);
+		}, function(){
+			// There was an error re-importing modules
+			// Workers don't have a location and no way to refresh the page.
+			if(loader.global.location && loader.global.location.reload) {
+				loader.global.location.reload();
+			}
+		});
+	}
 
-	var depName;
-	for(var i = 0, len = oldDeps.length; i < len; i++) {
-		depName = oldDeps[i];
-		if(!~deps.indexOf(depName)) {
-			var dependants = loader.getDependants(depName);
-			// Only teardown if this is the only dependant module.
-			if(dependants.length === 1) {
-				disposeModule(depName, loader._liveEmitter);
+	function removeOrphans(moduleName, oldDeps){
+		var deps = loader.getDependencies(moduleName) || [];
+
+		var depName;
+		for(var i = 0, len = oldDeps.length; i < len; i++) {
+			depName = oldDeps[i];
+			if(!~deps.indexOf(depName)) {
+				var dependants = loader.getDependants(depName);
+				// Only teardown if this is the only dependant module.
+				if(dependants.length === 1) {
+					disposeModule(depName, loader._liveEmitter);
+				}
 			}
 		}
 	}
-}
 
-function setup(){
-	if(loader.liveReload === "false" || loader.liveReload === false) {
-		return;
-	}
-
-	var port = loader.liveReloadPort || 8012;
-
-	var host = loader.liveReloadHost || window.document.location.host.replace(/:.*/, '');
-	var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-	var url = protocol + "//" + host + ":" + port;
-	var ws = new WebSocket(url);
-
-	// Let the server know about the main module
-	var onopen = ws.onopen = function(){
-		ws.send(loader.main);
-	};
-
-	var onmessage = ws.onmessage = function(ev){
-		var moduleName = ev.data;
-		reloadAll(moduleName);
-	};
-
-	var attempts = typeof loader.liveReloadAttempts !== "undefined" ?
-		loader.liveReloadAttempts - 1 : 0;
-	var onclose = ws.onclose = function(ev){
-		// 1006 means it was unable to connect to a server.
-		if(ev.code === 1006 && attempts > 0) {
-			attempts--;
-			setTimeout(function(){
-				ws = new WebSocket(url);
-				ws.open = onopen;
-				ws.onmessage = onmessage;
-				ws.onclose = onclose;
-			}, loader.liveReloadRetryTimeout || 500);
+	function setup(){
+		if(loader.liveReload === "false" || loader.liveReload === false) {
+			return;
 		}
-	};
-}
 
-var isBuildEnvironment = loader.isPlatform ?
-	(loader.isPlatform("build") || loader.isEnv("build")) :
-	(typeof window === "undefined");
+		var port = loader.liveReloadPort || 8012;
 
-if(!isBuildEnvironment) {
-	if(typeof steal !== "undefined") {
-		steal.done().then(setup);
+		var host = loader.liveReloadHost || window.document.location.host.replace(/:.*/, '');
+		var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+		var url = protocol + "//" + host + ":" + port;
+		var ws = new WebSocket(url);
+
+		// Let the server know about the main module
+		var onopen = ws.onopen = function(){
+			ws.send(loader.main);
+		};
+
+		var onmessage = ws.onmessage = function(ev){
+			var moduleName = ev.data;
+			reloadAll(moduleName);
+		};
+
+		var attempts = typeof loader.liveReloadAttempts !== "undefined" ?
+			loader.liveReloadAttempts - 1 : 0;
+		var onclose = ws.onclose = function(ev){
+			// 1006 means it was unable to connect to a server.
+			if(ev.code === 1006 && attempts > 0) {
+				attempts--;
+				setTimeout(function(){
+					ws = new WebSocket(url);
+					ws.open = onopen;
+					ws.onmessage = onmessage;
+					ws.onclose = onclose;
+				}, loader.liveReloadRetryTimeout || 500);
+			}
+		};
+	}
+
+	var isBuildEnvironment = loader.isPlatform ?
+		(loader.isPlatform("build") || loader.isEnv("build")) :
+		(typeof window === "undefined");
+
+	if(!isBuildEnvironment) {
+		if(typeof steal !== "undefined") {
+			steal.done().then(setup);
+		} else {
+			setTimeout(setup);
+		}
+
+		module.exports = reloadAll;
 	} else {
-		setTimeout(setup);
+		var metaConfig = loader.meta["live-reload"];
+		if(!metaConfig) {
+			metaConfig = loader.meta["live-reload"] = {};
+		}
+		// For the build, translate to a noop.
+		metaConfig.translate = function(load){
+			load.metadata.format = "amd";
+			return "def" + "ine([], function(){\n" +
+				"return function(){};\n});";
+		};
 	}
-
-	module.exports = reloadAll;
-} else {
-	var metaConfig = loader.meta["live-reload"];
-	if(!metaConfig) {
-		metaConfig = loader.meta["live-reload"] = {};
-	}
-	// For the build, translate to a noop.
-	metaConfig.translate = function(load){
-		load.metadata.format = "amd";
-		return "def" + "ine([], function(){\n" +
-			"return function(){};\n});";
-	};
 }
+
+addLiveReload(loader);

--- a/test/live_reload/unit.js
+++ b/test/live_reload/unit.js
@@ -54,6 +54,23 @@ QUnit.test("Can take an array of moduleNames to teardown", function(assert){
 	.then(done, done);
 });
 
+QUnit.module("Contextual live-reload module");
+
+QUnit.test("Can be cloned", function(assert){
+	var done = assert.async();
+
+	loader.import("live-reload", { name: "clone-test" })
+	.then(function(){
+		var clone = loader.clone();
+		return clone.import("live-reload", { name: "clone-test" });
+	})
+	.then(function(reload){
+		// Duck check that this is the contextual
+		assert.equal(typeof reload.isReloading, "function", "this function exists");
+	})
+	.then(done, done);
+});
+
 QUnit.module("reload.isReloading");
 
 QUnit.test("is false by default", function(assert){


### PR DESCRIPTION
This makes it so that the live-reload extension is cloneable, and
therefore doesn't cause errors when used with steal-clone in tests.

Closes #1213

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
