### PR TITLE
Fixes bug loading peer deps that are dev deps too

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -267,9 +267,13 @@ var crawl = {
 	 */
 	getFullDependencyMap: function(loader, packageJSON, isRoot){
 		var deps = crawl.getDependencyMap(loader, packageJSON, isRoot);
-		addDeps(packageJSON, packageJSON.devDependencies || {}, deps,
-			"devDependencies");
-		return deps;
+
+		return addMissingDeps(
+			packageJSON,
+			packageJSON.devDependencies || {},
+			deps,
+			"devDependencies"
+		);
 	},
 	getPlugins: function(packageJSON, deps) {
 		var config = utils.pkg.config(packageJSON) || {};
@@ -488,6 +492,22 @@ function addDeps(packageJSON, dependencies, deps, type, defProps){
 			deps[name] = val;
 		}
 	}
+}
+
+/**
+ * Same as `addDeps` but it does not override dependencies already set
+ */
+function addMissingDeps(packageJson, dependencies, deps, type, defProps) {
+	var without = {};
+
+	for (var name in dependencies) {
+		if (!deps[name]) {
+			without[name] = dependencies[name];
+		}
+	}
+
+	addDeps(packageJson, without, deps, type, defProps);
+	return deps;
 }
 
 /**

--- a/steal-sans-promises.production.js
+++ b/steal-sans-promises.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v1.5.5
+ *  steal v1.5.6
  *  
  *  Copyright (c) 2017 Bitovi; Licensed MIT
  */

--- a/steal.production.js
+++ b/steal.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v1.5.5
+ *  steal v1.5.6
  *  
  *  Copyright (c) 2017 Bitovi; Licensed MIT
  */

--- a/test/npm/bower/node_modules/steal/steal.production.js
+++ b/test/npm/bower/node_modules/steal/steal.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v1.5.5
+ *  steal v1.5.6
  *  
  *  Copyright (c) 2017 Bitovi; Licensed MIT
  */

--- a/test/npm/test.js
+++ b/test/npm/test.js
@@ -278,8 +278,7 @@ QUnit.test("With npm3 traversal starts by going to the mosted nested position", 
 	makeIframe("nested_back/dev.html", assert);
 });
 
-// TODO: Fix this test
-QUnit.skip("peerDependencies are matched against parent that has a matching version", function(assert){
+QUnit.test("peerDependencies are matched against parent that has a matching version", function(assert){
 	makeIframe("peer_deps/dev.html", assert);
 });
 


### PR DESCRIPTION
Closes #1228 

So, we already faced this problem before... I remember skipping this test while I was migrating steal-npm but forgot to file an issue to check why it was failing.

The issue is caused by the following scenario (in the test):

// package.json
```json
dependencies: {
   "@cycle/core": "^6.0.0",
  "rx": "^4.0.7"
}
```

// cycle/core's package.json
```json
devDependencies: {
  "rx": "4.0.6"
},
peerDependencies: {
  "rx": "*"
}
```

When the npm extension is normalizing `@cycle/core ->rx`, it grabs the version inside `devDependencies` which is not compatible with the one in the top package.json.

https://github.com/stealjs/steal/blob/d0e96bae5c672bfd859e9e13eef9e2e53f52163b/ext/npm-extension.js#L123

That line is the issue since it uses `getFullDependencyMap` which uses the packages inside `devDependencies`; I'm not sure what should be the condition to ignore dev dependencies though. cc: @matthewp 


