### PR TITLE
Simplify mismatch version error message

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -665,24 +665,6 @@ utils.extend(FetchTask.prototype, {
 	},
 
 	/**
-	 * Returns an array of the package parents names
-	 * @param {string} name - The child package name
-	 * @return {Array.<string>} The list of package names (includes the child name)
-	 */
-	getPackageParentsNames: function(name) {
-		var res = [];
-		var context = this.context || {};
-		var parents = context.packageParents ? context.packageParents[name] : [];
-
-		for (var i = 0; i < parents.length; i += 1) {
-			res.push(parents[i].name);
-		}
-
-		res.push(parents.package ? parents.package.name : name);
-		return res;
-	},
-
-	/**
 	 * Get the next package to look up by traversing up the node_modules.
 	 * Create a new pkg by extending the existing one
 	 */
@@ -699,13 +681,24 @@ utils.extend(FetchTask.prototype, {
 		else {
 			// make sure we aren't loading something we've already loaded
 			var parentAddress = utils.path.parentNodeModuleAddress(fileUrl);
-			if(!parentAddress) {
-				throw new Error([
-					"Did not find " + pkg.origFileUrl,
-					"Unable to find a compatible version of " + pkg.name + "@" + pkg.version,
-					"Deps: " + this.getPackageParentsNames(pkg.name).join(" -> ")
-				].join("\n"));
+
+			if (!parentAddress) {
+				var found = this.getPackage();
+
+				if (!parentAddress) {
+					var found = this.getPackage();
+
+					throw new Error(
+						[
+							"Did not find " + pkg.origFileUrl,
+							"Unable to find a compatible version of " + pkg.name,
+							"Wanted: " + pkg.version,
+							found ? "Found: " + found.version : ""
+						].join("\n")
+					);
+				}
 			}
+
 			var nodeModuleAddress = parentAddress + "/" + pkg.name +
 				"/package.json";
 

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -828,8 +828,9 @@ QUnit.test("descriptive version mismatch error (#1176)", function(assert) {
 					err.message.split("\n"),
 					[
 						"Did not find ./node_modules/can-util/package.json",
-						"Unable to find a compatible version of can-util@^2.0.0",
-						"Deps: can -> can-util"
+						"Unable to find a compatible version of can-util",
+						"Wanted: ^2.0.0",
+						"Found: 1.0.0"
 					],
 					"should throw descriptive error message"
 				);


### PR DESCRIPTION
TL; DR 

The error message looks like this now:

```
Did not find [pkg.origFileUrl],
Unable to find a compatible version of [pkg.name]
Wanted: [pkg.version]
Found: [found.version]
```

Long version.

The previous version was printing out all the package names that had [pkg.name] (the one failing to load) as a dependency, regardless of which version they depended on. That's why it was printing out a lot of crazy stuff in Kevin's scenario.

I played with the method (maybe a lot longer that I should have) that gets the parent names to make sure it matches a given version (1)

The thing is, the package that depends on the version causing the error won't be in the npm extension state because steal throws when it's loading it 😄 , so what we can do is tell the user what packages depend on the last version successfully loaded.

Something like:

```
...
Found: [can,can-stache,can-react] -> can-util@^1.0.0
```

I didn't think all the code below was worth that piece of information; I guess we could add more state to the npm extension some how to improve the error message but not sure how to do it or if it's worth the time.

fwiw, the full (updated) error message in Kevin's branch seems a lot better than what we have now:

![screen shot 2017-08-08 at 18 04 41](https://user-images.githubusercontent.com/724877/29100062-757a2f88-7c66-11e7-968f-e9eac14a82ea.png)
 

1)
```js
function getPackageParentsNames(name, version) {
  var res = [];
  var context = this.context || {};

  // holds a map of all packages that depend on [name]
  var parents = context.packageParents ? context.packageParents[name] : [];

  // gets the version of [name] that [pkg] needs.
  var getDependencyVersion = function(pkg, name) {
    return (
      (pkg.dependencies || {})[name] ||
      (pkg.devDependencies || {})[name] ||
      (pkg.peerDependencies || {})[name]
    );
  };

  for (var i = 0; i < parents.length; i += 1) {
    var pkg = parents[i];
    var depVersion = getDependencyVersion(pkg, name);

    if (depVersion === version) {
      if (res.indexOf(pkg.name) === -1) {
        res.push(pkg.name);
      }
    }
  }

  return res;
}
```

Closes #1176

