### PR TITLE
Add plugins configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Additionally, plugins make it possible to load ANY module type you might come up
 
 ## Extending `steal` with Plugins
 
-The StealJS organization maintains popular plugins that extend and enhance the module-loading capablitities of `steal` (and, subsequently, `steal-tools`) such as:
+The StealJS organization maintains popular plugins that extend and enhance the module-loading capabilities of `steal` (and, subsequently, `steal-tools`) such as:
 
   - [CSS](https://github.com/stealjs/steal-css)
   - [Less](https://github.com/stealjs/steal-less)

--- a/docs/module-npm.md
+++ b/docs/module-npm.md
@@ -20,10 +20,10 @@ By default, if [config.stealPath] points to steal.js within node_modules like:
 [config.configMain] will point to `"package.json!npm"`. The `npm` plugin
 reads `package.json` and sets a normalize and locate hook.
 
-**Note**: if you are using NPM 3 see the *npmAlgorithm* option below.
+**Note**: if you are using npm 3 see the *npmAlgorithm* option below.
 
 
-## NPM Module names
+## npm Module names
 
 Package dependency module names are converted to look like: 
 
@@ -107,7 +107,7 @@ imported.  This path that `my-main` will be found depends on the `directories.li
 ### package.steal.map
 
 The map config works similar to the base [config.map] behavior.  However, both the keys and values
-are converted to NPM module names.  The keys and values must:
+are converted to npm module names.  The keys and values must:
 
  - Start with `./` to map modules within the package like `"./src/util"`, or
  - Look like `packageName#./modulePath` to map direct dependencies of the package.
@@ -212,9 +212,9 @@ Even though `npmIgnore` is set to ignore all `devDependencies` the use of `npmDe
 
 Used to determine which algorithm is used to look up packages.
 
-The default algorithm is `flat`. **We assume that you are using NPM 3 or higher.** See [here](https://github.com/npm/npm/releases/tag/v3.0.0) more about the flat file structure of NPM 3.
+The default algorithm is `flat`. **We assume that you are using npm 3 or higher.** See [here](https://github.com/npm/npm/releases/tag/v3.0.0) more about the flat file structure of npm 3.
 
-If you are using NPM 2 your dependencies of `node_modules` will be nested. StealJS can handle the lookup by setting `npmAlgorithm` to `nested`.
+If you are using npm 2 your dependencies of `node_modules` will be nested. StealJS can handle the lookup by setting `npmAlgorithm` to `nested`.
 
 ```js
 {

--- a/docs/module-steal-clone.md
+++ b/docs/module-steal-clone.md
@@ -108,6 +108,6 @@ loader.import('moduleB').then(function(){
 
 You will be able to override the value of `moduleB`. Note that for this to work you must import [@loader] to use for dynamic loading instead of using `steal.import`. This is because `@loader` will refer to the cloned loader you created where as `steal.loader` always refers back to the global loader. Using [@loader] is always recommended anyways.
 
-### Use with Bower or NPM
+### Use with Bower or npm
 
-Steal-clone can be used to override dependencies from [Bower](http://stealjs.com/docs/bower.html) or [NPM](http://stealjs.com/docs/npm.html) in the same way as any other module.
+Steal-clone can be used to override dependencies from [Bower](http://stealjs.com/docs/bower.html) or [npm](http://stealjs.com/docs/npm.html) in the same way as any other module.

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -66,7 +66,7 @@
 
 ### steal
 
-- Support added for [NPM 3](https://github.com/stealjs/steal/pull/522).
+- Support added for [npm 3](https://github.com/stealjs/steal/pull/522).
 - Support added for [scoped packages](https://github.com/stealjs/system-npm/pull/78).
 
 ## 0.12.0

--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -3,7 +3,7 @@
 
 @body
 
-Steal allows you to configure module loading through a **steal** property in your package.json. If you're not using Steal through NPM (you should be) you can also configure using any of the options provided by [config.config].
+Steal allows you to configure module loading through a **steal** property in your package.json. If you're not using Steal through npm (you should be) you can also configure using any of the options provided by [config.config].
 
 A basic configuration might look like this:
 

--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -12,13 +12,16 @@ A basic configuration might look like this:
   ...
   "steal": {
     "meta": {
-	  "jquery-plugin": {
+      "jquery-plugin": {
         "deps": ["jquery"]
       }
-	},
-	"paths": {
+    },
+    "paths": {
       "some-dep": "lib/some/dep.js"
-	}
+    },
+    "plugins": [
+      "steal-css"
+    ]
   }
 }
 ```
@@ -70,6 +73,32 @@ import foo from "foo";
 ```
 
 Will get the `FOO` global.
+
+## Plugins
+
+Plugins (such as [steal-css](https://www.npmjs.com/package/steal-css)) should be installed as `devDependencies` and added to the `plugins` configuration in your `package.json`.
+
+For example, to use `steal-css`, first install it with npm:
+
+```
+npm install steal-css --save-dev
+```
+
+Then update the `plugins` configuration in your `package.json`:
+
+```json
+{
+  ...
+  "devDependencies": {
+    ...
+    "steal-css": "^1.0.0"
+  },
+  "steal": {
+    ...
+    "plugins": ["steal-css"]
+  }
+}
+```
 
 ## Progressively loaded bundles
 

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -278,7 +278,7 @@ website. To edit the docs:
   
         > git clone https://github.com/stealjs/stealjs.git
 
-3. Install NPM dependencies:
+3. Install npm dependencies:
 
         > npm install
 

--- a/docs/pages/migrating.md
+++ b/docs/pages/migrating.md
@@ -58,7 +58,7 @@ The old Steal was chainable using `.then`, but this produced numerous problems t
 
 The old Steal always produced a `production.js` file, but this is no longer the case. Though configurable, by default the new Steal will place the production file in `dist/bundles` and it will be named after your main module.
 
-You will also need to add the following to your `stealconfig.js` file to be able to build the CanJS projects (note if you are using NPM this isn't necessary):
+You will also need to add the following to your `stealconfig.js` file to be able to build the CanJS projects (note if you are using npm this isn't necessary):
 
 ```js
 steal.config({

--- a/docs/pages/project-exporting.md
+++ b/docs/pages/project-exporting.md
@@ -5,7 +5,7 @@ StealJS can export your project into commonly used formats and platforms
 which can be used to create distributables that can be used in almost any situation:
 
  - [syntax.amd] and Bower
- - [syntax.CommonJS] and NPM for [Browserify](http://browserify.org/)
+ - [syntax.CommonJS] and npm for [Browserify](http://browserify.org/)
  - [syntax.es6 ES Syntax] and StealJS, SystemJS, or JSPM
  - [syntax.global global format] and `<script>` tags
 
@@ -167,7 +167,7 @@ with the files needed to use your project AMD, CommonJS and  `<script>` tags res
 For now, you should inspect these files and make sure they work. Eventually,
 we may release helpers that make it easy to test your distributables.
 
-### To NPM
+### To npm
 
 Run:
 
@@ -219,7 +219,7 @@ Once bower is setup, publishing to bower just means pushing a
 Developers need to know how to use your project. The following demonstrates what you need to tell them
 depending on how they are using your project.
 
-### NPM and StealJS
+### npm and StealJS
 
 Simply import, require, or use define to load your project.
 
@@ -230,7 +230,7 @@ define(["bit-tabs"], function(){});
 ```
 
 
-### NPM and CJS
+### npm and CJS
 
 Simply require your project.
 

--- a/docs/pages/why.md
+++ b/docs/pages/why.md
@@ -4,7 +4,7 @@
 StealJS is a dependency loader and build tool that solves the most difficult parts of building large JavaScript applications. With it's focus on simplified workflows and highly efficient production builds, we hope that StealJS is the last module loader you'll ever need. If you haven't checked out StealJS yet, we provide:
 
 *   A [production bundler and optimizer][2] that speeds up application load times by balancing caching and resource requests.
-*   [Easy workflows][3] for use with NPM and/or Bower. Less and CSS are supported out of the box.
+*   [Easy workflows][3] for use with npm and/or Bower. Less and CSS are supported out of the box.
 *   A powerful [exporting tool][4] for library authors so your module can reach users regardless of whether they are using StealJS, Browserify, RequireJS, SystemJS or WebPack.
 *   A module loader based on ES6, but providing compatibility with CommonJS and AMD.
 
@@ -36,7 +36,7 @@ For more traditional sites (not single page applications) you might have your ap
 
 ### Package Managers
 
-The rise of package managers like NPM and Bower has changed the way developers write applications today. Unfortunately this alone didn't make it easier to use your dependencies in your projects. In traditional module loaders like RequireJS you would have to configure these dependencies one-by-one.
+The rise of package managers like npm and Bower has changed the way developers write applications today. Unfortunately this alone didn't make it easier to use your dependencies in your projects. In traditional module loaders like RequireJS you would have to configure these dependencies one-by-one.
 
     require.config({
       paths: {
@@ -48,9 +48,9 @@ The rise of package managers like NPM and Bower has changed the way developers w
 
 This is tedious and error-prone. Once apps scale your config becomes more complex and harder to read. If any of the packages have their own dependencies you'll have to configure those as well. The result is that most client-side libraries have between 0 and 1 dependency.
 
-Some newer loaders like Webpack and Browserify side-step this problem by requiring you use NPM with a build script. This solves the dependency problem but creates new ones. In large applications where you might have many demo and test pages you now have to create separate bundles for each of these.
+Some newer loaders like Webpack and Browserify side-step this problem by requiring you use npm with a build script. This solves the dependency problem but creates new ones. In large applications where you might have many demo and test pages you now have to create separate bundles for each of these.
 
-We think it can be better than this. The user shouldn't have to configure their loader but they also shouldn't be forced to start off a project by writing a build script. So we built Bower and NPM plugins that allow you to use these package managers but still have the convenience that browser-based module loaders provide.
+We think it can be better than this. The user shouldn't have to configure their loader but they also shouldn't be forced to start off a project by writing a build script. So we built Bower and npm plugins that allow you to use these package managers but still have the convenience that browser-based module loaders provide.
 
 Consider you are starting a new three.js project. With npm you would install Three like so:
 
@@ -62,7 +62,7 @@ What this does in the background is save an entry in "dependencies" inside of yo
     <script src="node_modules/steal/steal.js"></script>
     
 
-StealJS will know that you're using NPM and look up your package.json for metadata. For you it's as simple as saving and then using:
+StealJS will know that you're using npm and look up your package.json for metadata. For you it's as simple as saving and then using:
 
     import THREE from "three";
     

--- a/docs/steal.md
+++ b/docs/steal.md
@@ -23,11 +23,11 @@ There are four basic steps when using Steal:
 Steal works slightly differently depending on how it is installed.  There
 are three ways to install Steal:
 
- - [npm](#section_NPMbasics)
+ - [npm](#section_npmbasics)
  - [bower](#section_Bowerbasics)
  - [download](#section_Downloadbasics)
 
-## NPM basics
+## npm basics
 
 The following details how to use steal installed via [npm](https://www.npmjs.com/) to make
 a simple jQuery app.
@@ -100,7 +100,7 @@ $("body").append("<h1>Hello World</h1>")
 
 ### Importing in your app
 
-From here using packages is the same as if you used NPM, just import them into
+From here using packages is the same as if you used npm, just import them into
 _myapp.js_ and do what you need:
 
 ```js

--- a/docs/type-moduleIdentifier.md
+++ b/docs/type-moduleIdentifier.md
@@ -10,7 +10,7 @@ The string passed into import functions such as `require()` when using CommonJS,
 A **moduleIdentifier** is a string written in code to import a module. It could be:
 
 * Relative to the current module like `'./foo'`.
-* The name of an NPM dependency of your project like `'lodash'`.
+* The name of an npm dependency of your project like `'lodash'`.
 * The name you are using to refer to a module that has been [config.map mapped] to another [moduleName].
 
 When Steal imports your code it sees the moduleIdentifiers and through [steal.hooks.normalize normalization] it converts these to [moduleName moduleNames] that it uses as keys in the module registry.

--- a/docs/type-moduleName.md
+++ b/docs/type-moduleName.md
@@ -50,7 +50,7 @@ However, if the parent module does *not* have an npm dependency on lodash then t
 
 ## npm module names
 
-When importing modules installed with npm the moduleName normalizes to something like `lodash@1.0.0#main`. While strange looking this form has a purpose. Remember that each moduleName in the registry must be *unique*. NPM packages, however, are not, and nested dependencies can use different versions of the same package. When this happens it's important that each module gets a [semver compatible](http://semver.org/) version of the package they need.
+When importing modules installed with npm the moduleName normalizes to something like `lodash@1.0.0#main`. While strange looking this form has a purpose. Remember that each moduleName in the registry must be *unique*. npm packages, however, are not, and nested dependencies can use different versions of the same package. When this happens it's important that each module gets a [semver compatible](http://semver.org/) version of the package they need.
 
 Here are the parts of an npm moduleName, using `lodash@1.0.0#main`:
 

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -275,7 +275,7 @@ exports.addExtension = function(System){
 					}
 
 					// If locate didn't do the expected thing then we're going
-					// to guess that we shouldn't perform NPM lookup on this
+					// to guess that we shouldn't perform npm lookup on this
 					// module as there might be a wildcard path.
 					if(address !== expectedAddress + ".js" &&
 					  address !== expectedAddress) {
@@ -348,7 +348,7 @@ exports.addExtension = function(System){
 			if (error.statusCode === 404 && utils.moduleName.isBareIdentifier(load.name)) {
 				throw new Error([
 					"Could not load '" + load.name + "'",
-					"Is this an NPM module not saved in your package.json?"
+					"Is this an npm module not saved in your package.json?"
 				].join("\n"));
 			} else {
 				throw error;

--- a/test/npm/import_test.js
+++ b/test/npm/import_test.js
@@ -454,7 +454,7 @@ QUnit.test("importing a package with an unsaved dependency", function(assert) {
 			}, function(err) {
 				assert.ok(/Could not load 'dep'/.test(err.message));
 				assert.ok(
-					/Is this an NPM module not saved/.test(err.message),
+					/Is this an npm module not saved/.test(err.message),
 					"should throw a descriptive error message"
 				);
 				done();

--- a/test/npm/npm-deep/node_modules/steal/ext/npm-extension.js
+++ b/test/npm/npm-deep/node_modules/steal/ext/npm-extension.js
@@ -252,7 +252,7 @@ exports.addExtension = function(System){
 					}
 
 					// If locate didn't do the expected thing then we're going
-					// to guess that we shouldn't perform NPM lookup on this
+					// to guess that we shouldn't perform npm lookup on this
 					// module as there might be a wildcard path.
 					if(address !== expectedAddress + ".js" &&
 					  address !== expectedAddress) {


### PR DESCRIPTION
Also fixed NPM -> npm and “capabilities” typo in the README.

Fixes https://github.com/stealjs/stealjs/issues/34