### PR TITLE
Apply mappings when left-side is not a pkg but right-side is.

### DIFF
--- a/ext/npm-convert.js
+++ b/ext/npm-convert.js
@@ -122,6 +122,10 @@ function convertPropertyNamesAndValues (context, pkg, map, root, waiting) {
 		if(typeof name !== 'undefined' && typeof val !== 'undefined') {
 			clone[name] = val;
 		}
+		// keep map entry if the key isn't a package but value might
+		if (name && typeof val === "undefined") {
+			clone[name] = map[property];
+		}
 	}
 	return clone;
 }

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -841,7 +841,7 @@ QUnit.test("descriptive version mismatch error (#1176)", function(assert) {
 		.then(done, helpers.fail(assert, done));
 });
 
-QUnit.skip("'map' configuration where the right-hand identifier is an npm package but the left is not", function(assert){
+QUnit.test("'map' configuration where the right-hand identifier is an npm package but the left is not", function(assert){
 	var done = assert.async();
 
 	var loader = helpers.clone()


### PR DESCRIPTION
Closes #1208

The app in the original issue runs ok with this branch https://github.com/m-mujica/steal-preact-compat-map

![google chrome](https://user-images.githubusercontent.com/724877/30559645-b0d12a1a-9c8b-11e7-9b04-9bf8dba85b43.png)
