### PR TITLE
Fix issue breaking live-reload when used with dynamic-import

### DIFF
--- a/ext/live-reload.js
+++ b/ext/live-reload.js
@@ -269,13 +269,15 @@ function addLiveReload(loader) {
 		if(loader.liveReload === "false" || loader.liveReload === false) {
 			return;
 		}
+		// Save this so we can use it outside the zone
+		var WS = WebSocket;
 
 		var port = loader.liveReloadPort || 8012;
 
 		var host = loader.liveReloadHost || window.document.location.host.replace(/:.*/, '');
 		var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 		var url = protocol + "//" + host + ":" + port;
-		var ws = new WebSocket(url);
+		var ws = new WS(url);
 
 		// Let the server know about the main module
 		var onopen = ws.onopen = function(){
@@ -294,7 +296,7 @@ function addLiveReload(loader) {
 			if(ev.code === 1006 && attempts > 0) {
 				attempts--;
 				setTimeout(function(){
-					ws = new WebSocket(url);
+					ws = new WS(url);
 					ws.open = onopen;
 					ws.onmessage = onmessage;
 					ws.onclose = onclose;

--- a/steal-sans-promises.production.js
+++ b/steal-sans-promises.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v1.5.14
+ *  steal v1.5.16
  *  
  *  Copyright (c) 2017 Bitovi; Licensed MIT
  */

--- a/steal.production.js
+++ b/steal.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v1.5.15
+ *  steal v1.5.16
  *  
  *  Copyright (c) 2017 Bitovi; Licensed MIT
  */


### PR DESCRIPTION
Closes canjs/can-view-parser#75

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
