### PR TITLE
Prevents buildConfig from overriding package's configuration

### DIFF
--- a/ext/npm-convert.js
+++ b/ext/npm-convert.js
@@ -55,7 +55,7 @@ function convertSteal(context, pkg, steal, root, ignoreWaiting, resavePackageInf
 	// needed for builds
 	if(steal.buildConfig) {
 		steal.buildConfig = convertSteal(context, pkg, steal.buildConfig,
-										  root, waiting);
+										  root, waiting, false);
 	}
 
 	// Push the waiting conversions down.


### PR DESCRIPTION
This prevents the `buildConfig`, which is used to have a special
configuration during the build, from overriding the rest of a package's
configuration, which needs to be carried over to production.

Fixes #1319

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
