### PR TITLE
Prevent 'Is this an npm module not saved' error

### DIFF
--- a/ext/npm-utils.js
+++ b/ext/npm-utils.js
@@ -397,7 +397,7 @@ var utils = {
 		 */
 		isRoot: function(loader, pkg) {
 			var root = utils.pkg.getDefault(loader);
-			return pkg.name === root.name && pkg.version === root.version;
+			return pkg && pkg.name === root.name && pkg.version === root.version;
 		},
 		homeAlias: function (context) {
 			return context && context.loader && context.loader.homeAlias || '~';

--- a/test/live_reload/package.json
+++ b/test/live_reload/package.json
@@ -6,7 +6,6 @@
   "author": "Bitovi",
   "license": "MIT",
   "devDependencies": {
-    "jquery": "^2.1.4",
     "live-reload-testing": "^5.1.0"
   }
 }

--- a/test/npm/import_test.js
+++ b/test/npm/import_test.js
@@ -457,6 +457,31 @@ QUnit.test("importing a package with an unsaved dependency", function(assert) {
 					/Is this an npm module not saved/.test(err.message),
 					"should throw a descriptive error message"
 				);
+				assert.equal(err.statusCode, 404, "Got a 404");
+				done();
+			});
+});
+
+QUnit.test("Importing a missing file doesn't give npm module error", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.loader;
+
+		loader["import"]("app/missing")
+			.then(function(app) {
+				assert.ok(false, "import call should not resolve");
+			}, function(err) {
+				assert.notOk(
+					/Is this an npm module not saved/.test(err.message),
+					"should not throw a npm module error message"
+				);
+				assert.equal(err.statusCode, 404, "got a 404");
 				done();
 			});
 });

--- a/test/npm/utils_test.js
+++ b/test/npm/utils_test.js
@@ -1,4 +1,5 @@
 var utils = require("../../ext/npm-utils");
+var loader = require("@loader");
 
 QUnit.module("npm-utils");
 
@@ -18,4 +19,15 @@ QUnit.test("utils.moduleName.isNpm works", function(assert) {
 	assert.notOk(isNpm("foo/#{bar}"), "not a valid npm package module name");
 	assert.notOk(isNpm("foo/#{bar.baz}"), "not a valid npm package module name");
 	assert.notOk(isNpm("foo#?bar.isBaz"), "not a valid npm package module name");
+});
+
+QUnit.test("utils.pkg.isRoot works when passed undefined as the pkg", function(assert){
+	var isRoot = utils.pkg.isRoot;
+
+	try {
+		isRoot(loader, undefined);
+		assert.ok(true, "did not throw");
+	} catch(ex) {
+		assert.notOk(true, "isRoot threw");
+	}
 });


### PR DESCRIPTION
This prevents the 'Is this an npm module not saved' error message when a
file is missing from the root package. This error is problematic because
it is never the problem that a dependency is not saved, in this
circumstance. Fixes #1332

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
