### PR TITLE
Prevent unhandled rejections caused by live-reload

### DIFF
--- a/ext/live-reload.js
+++ b/ext/live-reload.js
@@ -311,7 +311,7 @@ function addLiveReload(loader) {
 
 	if(!isBuildEnvironment) {
 		if(typeof steal !== "undefined") {
-			steal.done().then(setup);
+			steal.done().then(setup).then(null, Function.prototype);
 		} else {
 			setTimeout(setup);
 		}


### PR DESCRIPTION
live-reload creates a promise by waiting on `steal.done()` before doing
its WebSocket connection. Since this is a new promise, if steal.done()
	rejects, Node will show an unhandled rejection error. To fix we just
	ignore errors in this newly created promise; the errors will be
	handled elsewhere.

Closes #1348

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
