### PR TITLE
reload(callback) syntax now returns an error

### DIFF
--- a/docs/module-live-reload.md
+++ b/docs/module-live-reload.md
@@ -18,7 +18,7 @@ reload(function(){
 });
 ```
 
-@param {Function} callback A function to be called after a reload cycle is complete.
+@param {function(err)} callback A function to be called after a reload cycle is complete.
 
 @signature `reload(moduleName, callback)`
 
@@ -102,5 +102,20 @@ render();
 reload(function(){
 	render();
 });
+```
 
+## Error handling
+
+The *live-reload* module will include an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) if there is any error that occurs when reloading the module tree.
+
+```js
+import reload from "live-reload";
+
+reload(function(err) {
+  if(err) {
+    displayErrorMessage(err);
+  } else {
+    // Do whatever you normally do on a reload.
+  }
+});
 ```


### PR DESCRIPTION
This fixes #1350. If there is an error during live-reload, the `reload`
callback function will include the Error.

```js
import reload from "live-reload";

reload(function(err){
	if(err) {
		displayErrorMessage(err);
	} else {
		// Do whatever is normal
	}
});
```

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
