### PR TITLE
When a module is deleted, ensure any 'failed' records are removed

### DIFF
--- a/ext/live-reload.js
+++ b/ext/live-reload.js
@@ -114,6 +114,9 @@ function addLiveReload(loader) {
 				delete loader._liveListeners[moduleName];
 			}
 			return true;
+		} else {
+			// Delete it anyways to destroy extra state.
+			loader.delete(moduleName);
 		}
 		return false;
 	}

--- a/src/loader/lib/loader.js
+++ b/src/loader/lib/loader.js
@@ -1006,6 +1006,16 @@ function logloads(loads) {
       var loader = this._loader;
       delete loader.importPromises[name];
       delete loader.moduleRecords[name];
+	  if(this.failed) {
+		  var load;
+		  for(var i = 0; i < this.failed.length; i++) {
+			  load = this.failed[i];
+			  if(load.name === name) {
+				  this.failed.splice(i, 1);
+				  break;
+			  }
+		  }
+	  }
       return loader.modules[name] ? delete loader.modules[name] : false;
     },
     // 26.3.3.4 entries not implemented

--- a/src/loader/loader-sans-promises.js
+++ b/src/loader/loader-sans-promises.js
@@ -1042,6 +1042,16 @@ function logloads(loads) {
       var loader = this._loader;
       delete loader.importPromises[name];
       delete loader.moduleRecords[name];
+	  if(this.failed) {
+		  var load;
+		  for(var i = 0; i < this.failed.length; i++) {
+			  load = this.failed[i];
+			  if(load.name === name) {
+				  this.failed.splice(i, 1);
+				  break;
+			  }
+		  }
+	  }
       return loader.modules[name] ? delete loader.modules[name] : false;
     },
     // 26.3.3.4 entries not implemented

--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -2312,6 +2312,16 @@ function logloads(loads) {
       var loader = this._loader;
       delete loader.importPromises[name];
       delete loader.moduleRecords[name];
+	  if(this.failed) {
+		  var load;
+		  for(var i = 0; i < this.failed.length; i++) {
+			  load = this.failed[i];
+			  if(load.name === name) {
+				  this.failed.splice(i, 1);
+				  break;
+			  }
+		  }
+	  }
       return loader.modules[name] ? delete loader.modules[name] : false;
     },
     // 26.3.3.4 entries not implemented

--- a/steal.js
+++ b/steal.js
@@ -2312,6 +2312,16 @@ function logloads(loads) {
       var loader = this._loader;
       delete loader.importPromises[name];
       delete loader.moduleRecords[name];
+	  if(this.failed) {
+		  var load;
+		  for(var i = 0; i < this.failed.length; i++) {
+			  load = this.failed[i];
+			  if(load.name === name) {
+				  this.failed.splice(i, 1);
+				  break;
+			  }
+		  }
+	  }
       return loader.modules[name] ? delete loader.modules[name] : false;
     },
     // 26.3.3.4 entries not implemented


### PR DESCRIPTION
During live-reload we call `loader.delete()` to delete a module from the
registry. However we always first check if it is in the registry. This
change makes it so that we always call 'delete' and delete removes the
item from the `failed` array, if it exists.

Fixes #1357