### PR TITLE
Don't save the package.json of config set "late"

### DIFF
--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -433,7 +433,7 @@ exports.addExtension = function(System){
 			var context = loader.npmContext;
 			var pkg = context.versions.__default;
 			var conv = context.convert.steal(context, pkg, cfg, true);
-			context.convert.updateConfigOnPackageLoad(conv, context.resavePackageInfo,
+			context.convert.updateConfigOnPackageLoad(conv, false,
 				true, context.applyBuildConfig);
 			oldConfig.apply(loader, arguments);
 			return;

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -677,6 +677,9 @@ QUnit.test("Config applied before normalization will be reapplied after", functi
 	})
 	.then(function(name){
 		assert.equal(name, "dep@1.0.0#build");
+
+		var pkg = loader.npmContext.pkgInfo[0];
+-		assert.ok(!pkg.steal.map, "The map shoulded be applied to what saved into the build artifact");
 	})
 	.then(done, helpers.fail(assert, done));
 });
@@ -853,6 +856,7 @@ QUnit.test("buildConfig that is late-loaded doesn't override outer config", func
 	}).then(function(){
 		var pkg = loader.npmContext.pkgInfo[0];
 		assert.equal(pkg.steal.map["app@1.0.0#one"], "app@1.0.0#two", "Correct mapping in place");
+
 
 		assert.equal(loader.map["app@1.0.0#one"], "app@1.0.0#two", "Mapping not applied to the loader");
 	})


### PR DESCRIPTION
"Late" config is config that is set not part of the loading process but
stuff that is set later (like internally within steal-tools). This
should not be resaved because it is not part of a package's own
configuration and should not be reflected in production.