### PR TITLE
Implement the _newLoader hook for the npm extension

### DIFF
--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -447,6 +447,13 @@ exports.addExtension = function(System){
 		oldConfig.apply(loader, arguments);
 	};
 
+	// Implement the newLoader hook to copy config over during the build.
+	var newLoader = System._newLoader || Function.prototype;
+	System._newLoader = function(loader) {
+		loader.npmContext = this.npmContext;
+		loader.npmParentMap = this.npmParentMap;
+		return newLoader.apply(this, arguments);
+	};
 
 	steal.addNpmPackages = function(npmPackages) {
 		var packages = npmPackages || [];


### PR DESCRIPTION
Currently this configuration is copied over directly in steal-tools
(yuck!). With the new hook we no longer need to do that. This implements
_newLoader so we can get rid of that noise within steal-tools.
