### PR TITLE
Make envs map override configuration work

### DIFF
--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -217,8 +217,15 @@ exports.addExtension = function(System){
 				// Apply mappings, if they exist in the refPkg
 				var steal = utils.pkg.config(refPkg);
 				if (steal && steal.map && typeof steal.map[name] === "string") {
+					var mappedName = steal.map[name];
+					var envConfig = steal.envs && steal.envs[loader.env];
+
+					if(envConfig && envConfig.map && typeof envConfig.map[name] === "string") {
+						mappedName = envConfig.map[name];
+					}
+
 					return loader.normalize(
-						steal.map[name],
+						mappedName,
 						parentName,
 						parentAddress,
 						pluginNormalize

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -819,6 +819,49 @@ QUnit.test("'map' configuration where the right-hand identifier is an npm packag
 	.then(done, helpers.fail(assert, done));
 });
 
+QUnit.test("'map' configuration with envs config", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				mapped: "1.0.0"
+			},
+			steal: {
+				map: {
+					dep: "one"
+				},
+				envs: {
+					test: {
+						map: {
+							dep: "two"
+						}
+					}
+				}
+			}
+		})
+		/*.withPackages([
+			{
+				name: "mapped",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])*/
+		.loader;
+
+	loader.env = "test";
+	helpers.init(loader).then(function(){
+		return loader.normalize("dep", "app@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "two");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 QUnit.test("buildConfig that is late-loaded doesn't override outer config", function(assert){
 	var done = assert.async();
 


### PR DESCRIPTION
This fixes the issue presented in #1426 where a default map exists but
is overridden by config in `envs`.

Closes #1426
