### PR TITLE
Correctly load steal's package.json for Node builtins

### DIFF
--- a/ext/npm-crawl.js
+++ b/ext/npm-crawl.js
@@ -191,9 +191,14 @@ var crawl = {
 	 * Load steal and its dependencies, if needed
 	 */
 	loadSteal: function(context, pkg, isRoot, deps){
-		var stealPkg = utils.filter(deps, function(dep){
-			return dep && dep.name === "steal";
-		})[0];
+		var stealPkg, dep;
+		for(var p in deps) {
+			dep = deps[p];
+			if(dep.name === "steal") {
+				stealPkg = dep;
+				break;
+			}
+		}
 
 		if(stealPkg) {
 			return crawl.fetchDep(context, pkg, stealPkg, isRoot)

--- a/test/npm/helpers.js
+++ b/test/npm/helpers.js
@@ -8,7 +8,27 @@ function Runner(System){
 	this.sources = {};
 	this.fetchAllowed = {
 		"babel": true,
-		"@@babel-code-frame": true
+		"@@babel-code-frame": true,
+
+		/* Node built-in stuff */
+		"./node_modules/steal/package.json": true,
+		"./node_modules/assert/package.json": true,
+		"./node_modules/zlib-browserify/package.json": true,
+		"./node_modules/buffer/package.json": true,
+		"./node_modules/console-browserify/package.json": true,
+		"./node_modules/constants-browserify/package.json": true,
+		"./node_modules/crypto-browserify/package.json": true,
+		"./node_modules/domain-browser/package.json": true,
+		"./node_modules/events/package.json": true,
+		"./node_modules/http-browserify/package.json": true,
+		"./node_modules/https-browserify/package.json": true,
+		"./node_modules/os-browserify/package.json": true,
+		"./node_modules/path-browserify/package.json": true,
+		"./node_modules/process/package.json": true,
+		"./node_modules/punycode/package.json": true,
+		"./node_modules/string_decoder/package.json": true,
+		"./node_modules/tty-browserify/package.json": true,
+		"./node_modules/vm-browserify/package.json": true
 	};
 	this.fetchAll = false;
 }
@@ -27,6 +47,7 @@ Runner.prototype.clone = function(){
 	}));
 
 	loader.paths["live-reload"] = "node_modules/steal/ext/live-reload.js";
+	loader.paths["./node_modules/steal/package.json"] = "package.json";
 	loader.paths["babel"] = "ext/babel.js";
 	loader.paths["@@babel-code-frame"] = "ext/babel-code-frame.js";
 	loader.meta["@@babel-code-frame"] = {"format":"global","exports":"BabelCodeFrame"};

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -949,3 +949,25 @@ QUnit.test("late-loaded buildConfig is applied when in the build", function(asse
 	})
 	.then(done, helpers.fail(assert, done));
 });
+
+QUnit.test("Correctly normalizes built-ins", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				steal: "*"
+			}
+		})
+		.loader;
+
+	helpers.init(loader).then(function(){
+		return loader.normalize("util", "app@1.0.0#main");
+	}).then(function(name){
+		assert.ok(/steal@.+#ext\/builtin\/util/.test(name), "Is npm normalized");
+	})
+	.then(done, helpers.fail(assert, done));
+});


### PR DESCRIPTION
Loading Node builtins should happen automatically, because steal's own
package.json is loaded up-front. This fixes the behavior.

Closes #1428
