### PR TITLE
Better document the main configuration

### DIFF
--- a/docs/config-configMain.md
+++ b/docs/config-configMain.md
@@ -3,8 +3,8 @@
 
 The name of a module that is loaded before [@dev] and [config.main].
 
-@option {moduleName} A configuration module that is loaded before 
-the [config.main] module(s). This is where all configuration 
+@option {moduleName} A configuration module that is loaded before
+the [config.main] module(s). This is where all configuration
 should happen. The `configMain` module and all of its dependencies
 run during a build, so make sure they can operate without a DOM.
 
@@ -15,10 +15,12 @@ run during a build, so make sure they can operate without a DOM.
 
 The `configMain` name and path is typically specified with [config.configPath] in the steal.js `<script>` tag like:
 
-    <script src="../path/to/steal/steal.js"
-            config-path="../path/to/stealconfig.js"
-            main="app">
-    </script>
+```html
+<script src="../path/to/steal/steal.js"
+        config-path="../path/to/stealconfig.js"
+        main="app">
+</script>
+```
 
 This sets `configMain = "stealconfig.js"`.  
 
@@ -27,8 +29,8 @@ This sets `configMain = "stealconfig.js"`.
 
 If _steal.js_ is inside _node\_modules_ like:
 
-    <script src="../node_modules/steal/steal.js">
-    </script>
+```html
+<script src="../node_modules/steal/steal.js" main></script>
+```
 
 `configMain` will be set to `"package.json!npm"`.
-

--- a/docs/config-depsbundle.md
+++ b/docs/config-depsbundle.md
@@ -9,7 +9,7 @@ Specifies that you would like to use deps bundles, in the default location of [c
 
 ```html
 <script src="./node_modules/steal/steal.js"
-  deps-bundle></script>
+  deps-bundle main></script>
 ```
 
 @option {String}
@@ -18,5 +18,5 @@ Specifies a [moduleName], relative to the [config.baseURL], for the deps-bundle.
 
 ```html
 <script src="./node_modules/steal/steal.js"
-  deps-bundle="folder/dev-bundle"></script>
+  deps-bundle="folder/dev-bundle" main></script>
 ```

--- a/docs/config-devbundle.md
+++ b/docs/config-devbundle.md
@@ -9,7 +9,7 @@ Specifies that you would like to use dev bundles, in the default location of [co
 
 ```html
 <script src="./node_modules/steal/steal.js"
-  dev-bundle></script>
+  dev-bundle main></script>
 ```
 
 @option {String}
@@ -18,5 +18,5 @@ Specifies a [moduleName], relative to the [config.baseURL], for the dev-bundle. 
 
 ```html
 <script src="./node_modules/steal/steal.js"
-  dev-bundle="folder/dev-bundle"></script>
+  dev-bundle="folder/dev-bundle" main></script>
 ```

--- a/docs/config-env.md
+++ b/docs/config-env.md
@@ -1,7 +1,7 @@
 @property {String} config.env env
 @parent StealJS.config
 
-Specifies which environment the application is loading within. 
+Specifies which environment the application is loading within.
 
 @option {String} Any string value is possible.
 
@@ -14,12 +14,12 @@ Previously setting `env` was used to control when bundles were loaded, by settin
 `env` can be any string value and separated by a dash `-`. This is useful to, for example, set the environment as being both **production** and **server** if doing server-side rendering.
 
 ```html
-<script src="node_modules/steal/steal.js" env="window-production"></script>
+<script src="./node_modules/steal/steal.js" env="window-production" main="myapp"></script>
 ```
 
 ```js
-System.isEnv("production"); // true
-System.isPlatform("window"); // true
+steal.loader.isEnv("production"); // true
+steal.loader.isPlatform("window"); // true
 ```
 
-Rarely do you need to set `env` any more, more likely you want to use [config.loadBundles]. env is set by plugins in most cases. 
+Rarely do you need to set `env` any more, more likely you want to use [config.loadBundles]. env is set by plugins in most cases.

--- a/docs/config-loadBundles.md
+++ b/docs/config-loadBundles.md
@@ -37,7 +37,7 @@ be [config.config configured] via the `steal.js` script tag like:
 ```
 <script src="../path/to/steal/steal.js"
 		data-load-bundles
-        data-main="myapp">
+    data-main="myapp">
 </script>
 ```
 
@@ -48,6 +48,7 @@ Or specified prior to steal loading like:
   steal = { loadBundles: true };
 </script>
 <script src="../path/to/steal/steal.js"
-        data-env="production">
+        data-env="production"
+        data-main="myapp">
 </script>
 ```

--- a/docs/config-main.md
+++ b/docs/config-main.md
@@ -1,47 +1,88 @@
-@property {moduleName|Array<moduleName>} config.main main
+@property {Array<String>|String} config.main main
 @parent StealJS.config
 
-The name of the module(s) that loads all other modules in the application.
+The entry point of the application.
 
-  @option {moduleName} The main module to load after [config.configMain]. 
-  
-  @option {Array<moduleName>} An array of main modules that will be loaded after [config.configMain].
+@signature `main="packageName/main"`
 
+Loads an entry point by referencing it in association with the [config.packageName] of your application.
 
+```html
+<script src="node_modules/steal/steal.js"
+  main="todo-app/app"></script>
+```
+
+@param {String} packageName The name of the package from the package.json `name` field.
+
+@param {String} main The name of the entry module (usually a JavaScript file).
+
+@signature `main="~/main"`
+
+Loads an entry point by referencing in association with the [tilde homeAlias].
+
+```html
+<script src="node_modules/steal/steal.js"
+  main="~/app"></script>
+```
+
+@param {String} main The name of the entry module (usually a JavaScript file).
+
+@signature `{ main: "packageName/main" }`
+
+Loads an entry point by referencing the main in a configuration setting (such as within [steal-tools]). Any tool which takes a steal configuration object can accept a main, for example:
+
+```js
+const stealTools = require("steal-tools");
+
+stealTools.build({
+  config: __dirname + "/package.json!npm",
+  main: "todo-app/app"
+});
+```
+
+This method can also be used to configure steal within HTML, by setting the main prior to the steal script tag like so:
+
+```html
+<script>
+  steal = {
+    baseURL: "/apps/todos",
+    main: "~/main"
+  };
+</script>
+<script src="node_modules/steal/steal.js"></script>
+```
 
 @body
 
-## Use
+## Omitting the main
 
-This is the starting point of the application. In
-[config.env development], the `main` module is loaded after the [config.configMain] and [@dev] 
-modules. In [config.env production], only the `main` module is loaded, but 
-it is configured to load in a bundle.
+The __main__ module is not loaded by default. Merely adding a steal script tag will not load any code:
 
-Main should be configured by one of the approaches in [config.config].
-
-
-## Use with npm
-
-In [config.env development], your application's `package.json` will be read
-and the main module set automatically.  For instance, if 
-your package.json looks like:
-
-
-```
-{
-  "main": "my/main.js",
-  ...
-}
+```js
+<script src="node_modules/steal/steal.js"></script>
 ```
 
-The following will load `package.json` with the [npm] module and automatically load
-`my/main.js`:
+This is particular useful for demo pages where there isn't an associated JavaScript file for that particular page, and code is written inline using a [steal.steal-module] tag:
 
-```
-<script src="../node_modules/steal/steal.js">
-</script> 
+```js
+<div id="root"></div>
+
+<script src="node_modules/steal/steal.js"></script>
+
+<script type="steal-module">
+  import TodoList from "~/components/todo-list";
+
+  document.querySelector("#root").appendChild(new TodoList());
+</script>
 ```
 
-In [config.env production], make sure your script specifies `main` so the correct bundle to load
-can be known.
+## Missing main warning
+
+![No main is loaded](https://user-images.githubusercontent.com/361671/42763505-425adc50-88e1-11e8-9c01-17957b3f5ce5.png)
+
+This warning is reported to the console when steal starts and no other modules are loaded. This is usually a mistake as you wouldn't be using steal if you didn't intend to load modules with it. It could be that:
+
+* You forgot to include a `main` attribute in the steal script tag. See the above signatures for how to do that.
+* You intend to create an inline code demo using a [steal.steal-module] or one of the other techniques for loading code dynamically such as [steal.import].
+
+[steal] uses a heuristic to determine if this warning should be shown. If you believe the warning is shown by mistake please [submit an issue](https://github.com/stealjs/steal/issues/new).

--- a/docs/module-npm.md
+++ b/docs/module-npm.md
@@ -3,20 +3,20 @@
 
 @signature `moduleName!npm`
 
-@param {moduleName} moduleName The moduleName of the file you want 
+@param {moduleName} moduleName The moduleName of the file you want
 to process. This will normally be a package.json of your base application.
 
 @body
 
 ## Use
 
-The `npm` plugin makes it easy to work with npm packages. By pointing it 
+The `npm` plugin makes it easy to work with npm packages. By pointing it
 at a `package.json`, you will be able to import npm packages as modules.
 
 By default, if [config.stealPath] points to steal.js within node_modules like:
 
-    <script src="../node_modules/steal/steal.js"></script>
-    
+    <script src="../node_modules/steal/steal.js" main></script>
+
 [config.configMain] will point to `"package.json!npm"`. The `npm` plugin
 reads `package.json` and sets a normalize and locate hook.
 
@@ -25,7 +25,7 @@ reads `package.json` and sets a normalize and locate hook.
 
 ## npm Module names
 
-Package dependency module names are converted to look like: 
+Package dependency module names are converted to look like:
 
 > packageName@version#modulePath!pluginName
 
@@ -39,14 +39,14 @@ might actually import:
 
 ## Configuration
 
-`package.json` configures the behavior of a package and even dependency 
+`package.json` configures the behavior of a package and even dependency
 packages.  This section lists the configurable properties and behaviors that
 steal uses.  
 
 ### package.main
 
 Specifies the [config.main] property unless it is overwritten by `package.browser` or
-`package.steal.main`. 
+`package.steal.main`.
 
 ```
 {
@@ -56,7 +56,7 @@ Specifies the [config.main] property unless it is overwritten by `package.browse
 
 ### package.browser
 
-Specifies browser-specific overwrites for module file resolution.  This 
+Specifies browser-specific overwrites for module file resolution.  This
 behaves like Browserify's [browser field](https://github.com/substack/node-browserify#browser-field).
 
 ```
@@ -83,7 +83,7 @@ Global browser specific overwrites for module file resolution.  These mapping ta
 
 ### package.steal
 
-By default, any property on the package.steal object is passed to [config.config]. However, the 
+By default, any property on the package.steal object is passed to [config.config]. However, the
 following properties have special behavior:
 
 ### package.steal.main
@@ -100,7 +100,7 @@ The moduleName of the initial module that should be loaded when the package is i
 }
 ```
 
-When `my-module` is imported, `my-module@1.2.3#my-main` will be the actual module name being 
+When `my-module` is imported, `my-module@1.2.3#my-main` will be the actual module name being
 imported.  This path that `my-main` will be found depends on the `directories.lib` setting.
 
 
@@ -111,7 +111,7 @@ are converted to npm module names.  The keys and values must:
 
  - Start with `./` to map modules within the package like `"./src/util"`, or
  - Look like `packageName#./modulePath` to map direct dependencies of the package.
- 
+
 ```js
 {
   "steal": {
@@ -237,7 +237,7 @@ Set to true to ignore browserfy's `browser` and `browserify` configurations.
 
 ### package.steal.directories
 
-Set a folder to look for module's within your project.  Only the `lib` 
+Set a folder to look for module's within your project.  Only the `lib`
 directory can be specified.
 
 In the following setup, `my-project/my-utils` will be looked for in
@@ -272,7 +272,7 @@ is imported, e.g:
 
 ### package.steal.plugins
 
-Specifies packages that are used as plugins. These packages will be prefetched so that they're configuration will be applied before your app loads. An example is [steal-css]. 
+Specifies packages that are used as plugins. These packages will be prefetched so that they're configuration will be applied before your app loads. An example is [steal-css].
 
 ```js
 {

--- a/docs/scheme-tilde.md
+++ b/docs/scheme-tilde.md
@@ -60,4 +60,6 @@ Using ~ provides a shorter alias for your app's package name.
 
 Note that in production you need to use your app's package name in your script tag such as:
 
-    <script src="node_modules/steal/steal.js" main="app/main"></script>
+```html
+<script src="node_modules/steal/steal.js" main="app/main"></script>
+```

--- a/docs/steal-module.md
+++ b/docs/steal-module.md
@@ -9,7 +9,7 @@ Inline a module directly in HTML.
 
 Add a steal-module script to the page and it will run after Steal has been configured:
 
-    <script type="text/steal-module">
+    <script type="steal-module">
       import _ from "lodash";
 
 	  console.log(_.repeat("0", 10));


### PR DESCRIPTION
This improves the main configuration docs. It gives the various
signatures (ways that the main can be loaded), explains why you might
omit the main, and documents the warning when you don't load a main by
mistake.

Closes #1423 and #1424
