### PR TITLE
Fix using electron with an npm project

### DIFF
--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -341,7 +341,7 @@ exports.addExtension = function(System){
 		if(utils.moduleName.isNpm(load.name)) {
 			fetchPromise = fetchPromise.then(null, function(err){
 				var statusCode = err.statusCode;
-				if(statusCode !== 404 || statusCode !== 0) {
+				if(statusCode !== 404 && statusCode !== 0) {
 					return Promise.reject(err);
 				}
 
@@ -380,7 +380,7 @@ exports.addExtension = function(System){
 		}
 
 		return fetchPromise.catch(function(error) {
-			var statusCode = err.statusCode;
+			var statusCode = error.statusCode;
 			if ((statusCode === 404 || statusCode === 0) &&
 				utils.moduleName.isBareIdentifier(load.name) &&
 				!utils.pkg.isRoot(loader, load.metadata.npmPackage)) {

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -7,7 +7,8 @@ exports.includeInBuild = true;
 var isNode = typeof process === "object" && {}.toString.call(process) ===
 	"[object process]";
 var isWorker = typeof WorkerGlobalScope !== "undefined" && (self instanceof WorkerGlobalScope);
-var isBrowser = typeof window !== "undefined" && !isNode && !isWorker;
+var isElectron = isNode && !!process.versions.electron;
+var isBrowser = typeof window !== "undefined" && (!isNode || isElectron) && !isWorker;
 
 exports.addExtension = function(System){
 	if (System._extensions) {
@@ -339,7 +340,8 @@ exports.addExtension = function(System){
 
 		if(utils.moduleName.isNpm(load.name)) {
 			fetchPromise = fetchPromise.then(null, function(err){
-				if(err.statusCode !== 404) {
+				var statusCode = err.statusCode;
+				if(statusCode !== 404 || statusCode !== 0) {
 					return Promise.reject(err);
 				}
 
@@ -378,7 +380,8 @@ exports.addExtension = function(System){
 		}
 
 		return fetchPromise.catch(function(error) {
-			if (error.statusCode === 404 &&
+			var statusCode = err.statusCode;
+			if ((statusCode === 404 || statusCode === 0) &&
 				utils.moduleName.isBareIdentifier(load.name) &&
 				!utils.pkg.isRoot(loader, load.metadata.npmPackage)) {
 				var newError = new Error([

--- a/test/electron/electron.html
+++ b/test/electron/electron.html
@@ -17,7 +17,7 @@
 			versions: {
 				electron: "1.0.0"
 			},
-			platform: "eletron"
+			platform: "electron"
 		};
 
 		global = window;
@@ -30,6 +30,9 @@
 			return oldToString.apply(this, arguments);
 		};
 	</script>
-	<script src="../../steal-with-promises.js" config-main="@empty" base-url="./" main="main"></script>
+	<script src="../../steal-with-promises.js"
+		data-config="package.json!npm"
+		data-base-url="./"
+		data-main="~/main"></script>
 </body>
 </html>

--- a/test/electron/package.json
+++ b/test/electron/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "electron",
+  "main": "main.js",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
this fixes `locate` in an npm project that is using Electron. Previously
`locate` would incorrectly encode the URL because it thought it was not
running in a browser.

Fixes #1451