### PR TITLE
Fix additional case of ../ usage

### DIFF
--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -80,7 +80,9 @@ exports.addExtension = function(System){
 			var isInRoot = utils.path.isPackageRootDir(relativePath);
 
 			if(isInRoot) {
-				name = refPkg.name + "#" + utils.path.removeJS(refPkg.main);
+				name = refPkg.name + "#" + utils.path.removeJS(
+					utils.path.removeDotSlash(refPkg.main)
+				);
 
 			} else {
 				name = name + "index";

--- a/test/npm/normalize_test.js
+++ b/test/npm/normalize_test.js
@@ -314,7 +314,7 @@ QUnit.test("Loads npm convention of folder with trailing slash", function(assert
 		.withPackages([{
 			name: "dep",
 			version: "1.0.0",
-			main: "main.js"
+			main: "./lib/main.js"
 		}])
 		.loader;
 
@@ -348,18 +348,18 @@ QUnit.test("Loads npm convention of folder with trailing slash", function(assert
 	})
 	.then(function(name){
 		// Relative to parent-most is the pkg.main
-		assert.equal(name, "dep@1.0.0#main");
+		assert.equal(name, "dep@1.0.0#lib/main");
 
 		return loader.normalize("..", "dep@1.0.0#folder/mod");
 	})
 	.then(function(name){
 		// Relative to parent-most is the pkg.main
-		assert.equal(name, "dep@1.0.0#main");
+		assert.equal(name, "dep@1.0.0#lib/main");
 
 		return loader.normalize("./", "dep@1.0.0#thing");
 	})
 	.then(function(name){
-		assert.equal(name, "dep@1.0.0#main");
+		assert.equal(name, "dep@1.0.0#lib/main");
 	})
 	.then(done, done);
 });


### PR DESCRIPTION
This fixes a case where someone might use `../` to point to the
package.json main *and* the package.json contains `./` in it.
