### PR TITLE
Correctly encode git+ssh dependencies

### DIFF
--- a/ext/npm-utils.js
+++ b/ext/npm-utils.js
@@ -147,8 +147,14 @@ var utils = {
 				if(descriptor.modulePath) {
 					modulePath = descriptor.modulePath.substr(0,2) === "./" ? descriptor.modulePath.substr(2) : descriptor.modulePath;
 				}
+
+				var version = descriptor.version;
+				if(version) {
+					version = encodeURIComponent(decodeURIComponent(version));
+				}
+
 				return descriptor.packageName
-					+ (descriptor.version ? '@' + descriptor.version : '')
+					+ (version ? '@' + version : '')
 					+ (modulePath ? '#' + modulePath : '')
 					+ (descriptor.plugin ? descriptor.plugin : '');
 			}

--- a/ext/npm-utils.js
+++ b/ext/npm-utils.js
@@ -149,7 +149,7 @@ var utils = {
 				}
 
 				var version = descriptor.version;
-				if(version) {
+				if(version && version[0] !== "^") {
 					version = encodeURIComponent(decodeURIComponent(version));
 				}
 

--- a/test/npm/import_test.js
+++ b/test/npm/import_test.js
@@ -504,6 +504,34 @@ QUnit.test("named amd module with deps from a nested dependency", function(asser
 		});
 });
 
+QUnit.test("Imports git+ssh URLs that contain a hash", function(assert) {
+	var done = assert.async();
+
+	var depName = "dep@" + encodeURIComponent("git+ssh://git@example.com/company/my-lib.git#c23dr61") +
+		"#foo";
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				dep: "git+ssh://git@example.com/company/my-lib.git#c23dr61"
+			}
+		})
+		.withModule("app@1.0.0#main", "module.exports=require('dep/foo');")
+		.withModule(depName, "module.exports='works';")
+		.loader;
+
+	helpers.init(loader).then(function(){
+		return loader["import"]("app");
+	})
+	.then(function(mod){
+		assert.equal(mod, "works", "It worked!");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 QUnit.module("Error messages and warnings");
 
 QUnit.test("importing a package with an unsaved dependency", function(assert) {

--- a/test/saucelabs.js
+++ b/test/saucelabs.js
@@ -5,11 +5,11 @@ var testPagesUrls = require('./test-pages-urls');
 var platforms = [{
 	browserName: 'firefox',
 	platform: 'Windows 10',
-	version: '59.0'
+	version: '61.0'
 }, {
 	browserName: 'firefox',
 	platform: 'OS X 10.11',
-	version: '59.0'
+	version: '61.0'
 }, {
 	browserName: 'googlechrome',
 	platform: 'Windows 10'


### PR DESCRIPTION
Dependencies that use git+ssh can create moduleNames that interfere with
steal's moduleName parsing. URLs such as:

`git+ssh://git@example.com/company/my-lib.git#c23dr61`

Are problematic because they contain both an `@` and a `#` which have
special meaning.

The solution here is to encode the version number. For normal versions
like 1.0.0 this will not change anything. Only for these weird versions
that are actual URLs.

Fixes #1324 

This is being merged into the `1.0` branch first, then will be done to master.