### PR TITLE
use compact: false

### DIFF
--- a/src/extension-tree-shaking.js
+++ b/src/extension-tree-shaking.js
@@ -281,7 +281,8 @@ addStealExtension(function(loader) {
 					babelPlugins.push(treeShakePlugin.bind(null, loader, load));
 				}
 				var code = babel.transform(load.source, {
-					plugins: babelPlugins
+					plugins: babelPlugins,
+					compact: false
 				}).code;
 
 				// If everything is tree shaken still mark as ES6


### PR DESCRIPTION
use `compact: false` for transforming code.
see https://github.com/stealjs/steal-tools/issues/1071 for more information

close https://github.com/stealjs/steal-tools/issues/1071