### PR TITLE
Make steal-clone work with tree-shaken trees

### DIFF
--- a/ext/steal-clone.js
+++ b/ext/steal-clone.js
@@ -41,6 +41,14 @@ function cloneConfig(obj, isTopLevel) {
 		return clone;
 	}
 
+	if(obj instanceof Set) {
+		clone = new Set();
+		obj.forEach(function(item) {
+			clone.add(item);
+		});
+		return clone;
+	}
+
 	// instanceof fails to catch objects created with `null` as prototype
 	if (obj instanceof Object || toString.call(obj) === "[object Object]") {
 		clone = {};

--- a/test/test.js
+++ b/test/test.js
@@ -376,6 +376,10 @@ QUnit.test("Can disable tree shaking using treeShaking: false", function(assert)
 	makeIframe("tree_shake_reexport/tree-shaking-false.html", assert);
 });
 
+QUnit.test("Using steal-clone with a tree-shaken dep tree", function(assert){
+	makeIframe("tree_shake/steal-clone.html", assert);
+});
+
 QUnit.test("Can replace loads midway through the process", function(assert){
 	makeIframe("replace/site.html", assert);
 });

--- a/test/tree-shake-complex/site.html
+++ b/test/tree-shake-complex/site.html
@@ -11,7 +11,7 @@
 	</script>
 	<script
 		main="~/main"
-		src="../../../steal-with-promises.js"
+		src="../../steal-with-promises.js"
 		data-base-url="."
 		data-config="package.json!npm"></script>
 	<script>

--- a/test/tree_shake/anon.html
+++ b/test/tree_shake/anon.html
@@ -9,7 +9,7 @@
 		window.assert = window.parent.assert;
 		window.done = window.parent.done;
 	</script>
-	<script src="../../../steal-with-promises.js"
+	<script src="../../steal-with-promises.js"
 		data-base-url="."
 		data-config="package.json!npm"
 		data-main="@empty">

--- a/test/tree_shake/bundle.html
+++ b/test/tree_shake/bundle.html
@@ -10,7 +10,7 @@
 	window.done = window.parent.done;
 </script>
 <script
-	src="../../../steal-with-promises.js"
+	src="../../steal-with-promises.js"
 	data-main="@empty"
 	data-base-url="."
 	data-config="package.json!npm"></script>

--- a/test/tree_shake/dev.html
+++ b/test/tree_shake/dev.html
@@ -11,7 +11,7 @@
 	</script>
 	<script
 		main="~/main"
-		src="../../../steal-with-promises.js"
+		src="../../steal-with-promises.js"
 		data-base-url="."
 		data-config="package.json!npm"></script>
 	<script>

--- a/test/tree_shake/race.html
+++ b/test/tree_shake/race.html
@@ -9,7 +9,7 @@
 		window.assert = window.parent.assert;
 		window.done = window.parent.done;
 	</script>
-	<script src="../../../steal.js"
+	<script src="../../steal.js"
 		data-base-url="."
 		data-main="@empty"
 		data-config="package.json!npm"></script>

--- a/test/tree_shake/steal-clone.html
+++ b/test/tree_shake/steal-clone.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>Tree shaking with reexports</title>
+	<title>Tree shaking with steal-clone</title>
 </head>
 <body>
 	<script>
@@ -15,22 +15,23 @@
 		data-base-url="."
 		data-config="package.json!npm"></script>
 	<script>
-		function assertMain(mods) {
-			var main = mods[0];
-			if(typeof window.assert !== "undefined") {
-				assert.ok(main.Component);
-				assert.ok(main.DefineList);
-				assert.ok(main.DefineMap);
-				assert.ok(main.assign);
-				assert.ok(main.fixture);
-				assert.ok(main.stache);
-			} else {
-				console.log("main", main);
-			}
+		function runTests() {
+			return steal.loader.import("steal-clone", { name: steal.loader.main })
+			.then(function(clone) {
+				return clone({})
+				.import(steal.loader.main)
+				.then(function() {
+					if(window.assert) {
+						window.assert.ok(true, "It loaded");
+					} else {
+						console.log("it loaded successfully");
+					}
+				})
+			});
 		}
 
 		steal.done()
-		.then(assertMain)
+		.then(runTests)
 		.then(function(){
 			if(window.assert) {
 				window.done();

--- a/test/tree_shake_reexport/dev.html
+++ b/test/tree_shake_reexport/dev.html
@@ -11,7 +11,7 @@
 	</script>
 	<script
 		main="~/uses-core"
-		src="../../../steal-with-promises.js"
+		src="../../steal-with-promises.js"
 		data-base-url="."
 		data-config="package.json!npm"></script>
 	<script>

--- a/test/tree_shake_reexport/no-tree-shaking.html
+++ b/test/tree_shake_reexport/no-tree-shaking.html
@@ -10,7 +10,7 @@
 		window.done = window.parent.done;
 	</script>
 	<script
-		src="../../../steal-with-promises.js"
+		src="../../steal-with-promises.js"
 		data-base-url="."
 		data-config="package.json!npm"
 		data-no-tree-shaking></script>

--- a/test/tree_shake_reexport/tree-shaking-false.html
+++ b/test/tree_shake_reexport/tree-shaking-false.html
@@ -10,7 +10,7 @@
 		window.done = window.parent.done;
 	</script>
 	<script
-		src="../../../steal-with-promises.js"
+		src="../../steal-with-promises.js"
 		data-base-url="."
 		data-config="package.json!npm"></script>
 	<script>


### PR DESCRIPTION
tree-shaken dep trees uses Sets to store information about used exports.
When steal-clone copies configuration, it attempts to clone that
configuration. This makes it so that it detects Sets, and clones those
correctly. Fixes #1470

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
