### PR TITLE
warn with the importer in case of missing module

### DIFF
--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -393,11 +393,14 @@ exports.addExtension = function addNpmExtension(System){
 			if ((statusCode === 404 || statusCode === 0) &&
 				utils.moduleName.isBareIdentifier(load.name) &&
 				!utils.pkg.isRoot(loader, load.metadata.npmPackage)) {
-				var newError = new Error([
-					"Could not load '" + load.name + "'",
+				var errorMsg = ["Could not load '" + load.name + "'",
 					"Is this an npm module not saved in your package.json?"
-				].join("\n"));
+				].join("\n");
+				var newError = new Error();
 				newError.statusCode = error.statusCode;
+				newError.stack = newError.stack + error.stack;
+				newError.message = errorMsg;
+				
 				throw newError;
 			} else {
 				throw error;

--- a/ext/npm-extension.js
+++ b/ext/npm-extension.js
@@ -393,14 +393,12 @@ exports.addExtension = function addNpmExtension(System){
 			if ((statusCode === 404 || statusCode === 0) &&
 				utils.moduleName.isBareIdentifier(load.name) &&
 				!utils.pkg.isRoot(loader, load.metadata.npmPackage)) {
-				var errorMsg = ["Could not load '" + load.name + "'",
+				var newError = new Error([
+					"Could not load '" + load.name + "'",
 					"Is this an npm module not saved in your package.json?"
-				].join("\n");
-				var newError = new Error();
+				].join("\n"));
 				newError.statusCode = error.statusCode;
 				newError.stack = newError.stack + error.stack;
-				newError.message = errorMsg;
-				
 				throw newError;
 			} else {
 				throw error;

--- a/steal.production.js
+++ b/steal.production.js
@@ -1,5 +1,5 @@
 /*
- *  steal v2.1.12
+ *  steal v2.1.13
  *  
  *  Copyright (c) 2019 Bitovi; Licensed MIT
  */

--- a/test/npm_nested_import_errors/dep.js
+++ b/test/npm_nested_import_errors/dep.js
@@ -1,3 +1,2 @@
 module.exports = {};
-require('~/dep');
-
+require("~/foo");

--- a/test/npm_nested_import_errors/dev.html
+++ b/test/npm_nested_import_errors/dev.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+</head>
+<body>
+	<script>
+		window.done = window.parent.done;
+		window.assert = window.parent.assert;
+	</script>
+	<script src="../../steal-with-promises.js" main="@empty"
+	config="package.json!npm"
+	src="../../../steal-with-promises.js">
+		System.import('dep').then(null, function(err){
+			if(window.assert) {
+				var stack = err.stack;
+				window.assert.ok(/dep.js/.test(stack), "dep.js is in the stack");
+				window.done();
+			}
+		});
+	</script>
+</body>
+</html>

--- a/test/npm_nested_import_errors/dev.html
+++ b/test/npm_nested_import_errors/dev.html
@@ -9,16 +9,14 @@
 		window.done = window.parent.done;
 		window.assert = window.parent.assert;
 	</script>
-	<script src="../../steal-with-promises.js" main="@empty"
-	config="package.json!npm"
-	src="../../../steal-with-promises.js">
-		System.import('dep').then(null, function(err){
-			if(window.assert) {
-				var stack = err.stack;
-				window.assert.ok(/dep.js/.test(stack), "dep.js is in the stack");
-				window.done();
-			}
-		});
+	<script src="../../steal-with-promises.js" 
+		config="package.json!npm"
+		main="@empty">
+		steal.import('~/main').then(null, function(err){
+			var stack = err.stack;
+			window.assert.ok(/dep.js/.test(stack), "dep.js is in the stack");
+			window.done();
+		})
 	</script>
 </body>
 </html>

--- a/test/npm_nested_import_errors/main.js
+++ b/test/npm_nested_import_errors/main.js
@@ -1,0 +1,2 @@
+//require("dep");
+console.log("Imported");

--- a/test/npm_nested_import_errors/main.js
+++ b/test/npm_nested_import_errors/main.js
@@ -1,2 +1,0 @@
-//require("dep");
-console.log("Imported");

--- a/test/npm_nested_import_errors/package.json
+++ b/test/npm_nested_import_errors/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "npm_nested_import_errors",
+  "main": "main.js",
+  "version": "1.0.0",
+  "dependencies": {
+    "dep": "1.0.0"
+  }
+}

--- a/test/npm_nested_import_errors/package.json
+++ b/test/npm_nested_import_errors/package.json
@@ -1,8 +1,5 @@
 {
   "name": "npm_nested_import_errors",
   "main": "main.js",
-  "version": "1.0.0",
-  "dependencies": {
-    "dep": "1.0.0"
-  }
+  "version": "1.0.0"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ var QUnit = require("steal-qunit");
 
 QUnit.config.testTimeout = 30000;
 
-require("src/cache-bust/test/");
+// require("src/cache-bust/test/");
 require("src/env/test/");
 require("src/json/test/");
 require("src/trace/trace_test");
@@ -477,3 +477,7 @@ QUnit.test("dev bundle loads BEFORE configMain", function(assert) {
 QUnit.test("When the dev-bundle is missing we get a nice message", function(assert){
 	makeIframe("dev_bundle_err/dev.html", assert);
 });
+
+QUnit.test("If a package is missing, warn which file imported it #1463", function(assert) {
+	makeIframe("npm_nested_import_errors/dev.html", assert);	
+})

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ var QUnit = require("steal-qunit");
 
 QUnit.config.testTimeout = 30000;
 
-// require("src/cache-bust/test/");
+require("src/cache-bust/test/");
 require("src/env/test/");
 require("src/json/test/");
 require("src/trace/trace_test");


### PR DESCRIPTION
This adds the importer file of a missing module to the error message by prepending the stack to error.

Fixes https://github.com/stealjs/steal/issues/1463